### PR TITLE
Filter emails from free text

### DIFF
--- a/lib/top_secret.rb
+++ b/lib/top_secret.rb
@@ -3,6 +3,43 @@
 require_relative "top_secret/version"
 
 module TopSecret
+  # Modified from URI::MailTo::EMAIL_REGEXP
+  EMAIL_REGEX = %r{[a-zA-Z0-9.!\#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*}
+
   class Error < StandardError; end
-  # Your code goes here...
+
+  class Text
+    def initialize(input)
+      @input = input
+      @output = input.dup
+    end
+
+    def self.filter(input)
+      new(input).filter
+    end
+
+    def filter
+      emails = input.scan(EMAIL_REGEX)
+
+      emails.uniq.each.with_index(1) do |email, index|
+        filter = "EMAIL_#{index}"
+        output.gsub! email, "[#{filter}]"
+      end
+
+      Result.new(input, output)
+    end
+
+    private
+
+    attr_reader :output, :input
+  end
+
+  class Result
+    attr_reader :input, :output
+
+    def initialize(input, output)
+      @input = input
+      @output = output
+    end
+  end
 end

--- a/spec/top_secret_spec.rb
+++ b/spec/top_secret_spec.rb
@@ -5,3 +5,48 @@ RSpec.describe TopSecret do
     expect(TopSecret::VERSION).not_to be nil
   end
 end
+
+RSpec.describe TopSecret::Text do
+  describe ".filter" do
+    it "filters sensitive information from free text" do
+      input = <<~TEXT
+        My email address is user@example.com
+      TEXT
+
+      result = TopSecret::Text.filter(input)
+
+      expect(result.output).to eq(<<~TEXT)
+        My email address is [EMAIL_1]
+      TEXT
+      expect(result.input).to eq(input)
+    end
+
+    it "filters email addresses from free text" do
+      result = TopSecret::Text.filter("user@example.com")
+
+      expect(result.output).to eq("[EMAIL_1]")
+    end
+
+    it "returns a TopSecret::Result" do
+      result = TopSecret::Text.filter("")
+
+      expect(result).to be_an_instance_of(TopSecret::Result)
+    end
+
+    context "when there are multiple unique email addresses" do
+      it "filters each email address from free text" do
+        result = TopSecret::Text.filter("user_1@example.com user_2@example.com")
+
+        expect(result.output).to eq("[EMAIL_1] [EMAIL_2]")
+      end
+    end
+
+    context "when there are multiple identical email addresses" do
+      it "filters each email address from free text, and maps them to the same filter" do
+        result = TopSecret::Text.filter("user_1@example.com user_1@example.com")
+
+        expect(result.output).to eq("[EMAIL_1] [EMAIL_1]")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #4

Introduce basic interface and functionality for filtering email
addresses from free text based on `URI::MailTo::EMAIL_REGEXP`.

```ruby
input = "My email address is user@example.com"

result = TopSecret::Text.filter(input)
# => TopSecret::Result

result.output
# => "My email address is [EMAIL_1]"

result.input
# => "My email address is user@example.com"
```

We deliberately keep this interface simple. Once a more concrete pattern
emerges, we can create new abstractions.
