### PR TITLE
Filter credit card numbers from free text

### DIFF
--- a/lib/top_secret.rb
+++ b/lib/top_secret.rb
@@ -3,6 +3,8 @@
 require_relative "top_secret/version"
 
 module TopSecret
+  CREDIT_CARD_REGEX = /\b[3456]\d{15}\b/
+  CREDIT_CARD_REGEX_DELIMITERS = /\b[3456]\d{3}[\s+-]\d{4}[\s+-]\d{4}[\s+-]\d{4}\b/
   # Modified from URI::MailTo::EMAIL_REGEXP
   EMAIL_REGEX = %r{[a-zA-Z0-9.!\#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*}
 
@@ -20,10 +22,16 @@ module TopSecret
 
     def filter
       emails = input.scan(EMAIL_REGEX)
+      credit_cards = input.scan(CREDIT_CARD_REGEX_DELIMITERS) + input.scan(CREDIT_CARD_REGEX)
 
       emails.uniq.each.with_index(1) do |email, index|
         filter = "EMAIL_#{index}"
         output.gsub! email, "[#{filter}]"
+      end
+
+      credit_cards.uniq.each.with_index(1) do |credit_card, index|
+        filter = "CREDIT_CARD_#{index}"
+        output.gsub! credit_card, "[#{filter}]"
       end
 
       Result.new(input, output)


### PR DESCRIPTION
Filter credit card numbers from free text

Closes #3

Account for both delimited and non-delimited versions:

```
4242-4242-4242-4242
4242424242424242
```

Lifted from [Logstop][1].

[1]: https://github.com/ankane/logstop/blob/a44fe2d808444f6ad266ae7d3065bce386381619/lib/logstop.rb#L10-L11
