### PR TITLE
Add missing test coverage

### DIFF
--- a/spec/top_secret_spec.rb
+++ b/spec/top_secret_spec.rb
@@ -29,8 +29,14 @@ RSpec.describe TopSecret::Text do
       expect(result.output).to eq("[EMAIL_1]")
     end
 
-    it "filters delimited credit cards numbers from free text" do
+    it "filters delimited credit card numbers from free text" do
       result = TopSecret::Text.filter("4242-4242-4242-4242")
+
+      expect(result.output).to eq("[CREDIT_CARD_1]")
+    end
+
+    it "filters non-delimited credit card numbers from free text" do
+      result = TopSecret::Text.filter("4242424242424242")
 
       expect(result.output).to eq("[CREDIT_CARD_1]")
     end


### PR DESCRIPTION
Follow-up to #9

Adds missing unit test for non-delimited credit card numbers.
Technically, we have coverage in another unit test, but I wanted to keep
this granular too.
