### PR TITLE
Filter social security numbers from free text

### DIFF
--- a/lib/top_secret.rb
+++ b/lib/top_secret.rb
@@ -7,6 +7,7 @@ module TopSecret
   CREDIT_CARD_REGEX_DELIMITERS = /\b[3456]\d{3}[\s+-]\d{4}[\s+-]\d{4}[\s+-]\d{4}\b/
   # Modified from URI::MailTo::EMAIL_REGEXP
   EMAIL_REGEX = %r{[a-zA-Z0-9.!\#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*}
+  SSN_REGEX = /\b\d{3}[\s+-]\d{2}[\s+-]\d{4}\b/
 
   class Error < StandardError; end
 
@@ -23,6 +24,7 @@ module TopSecret
     def filter
       emails = input.scan(EMAIL_REGEX)
       credit_cards = input.scan(CREDIT_CARD_REGEX_DELIMITERS) + input.scan(CREDIT_CARD_REGEX)
+      ssns = input.scan(SSN_REGEX)
 
       emails.uniq.each.with_index(1) do |email, index|
         filter = "EMAIL_#{index}"
@@ -32,6 +34,11 @@ module TopSecret
       credit_cards.uniq.each.with_index(1) do |credit_card, index|
         filter = "CREDIT_CARD_#{index}"
         output.gsub! credit_card, "[#{filter}]"
+      end
+
+      ssns.each.with_index(1) do |ssn, index|
+        filter = "SSN_#{index}"
+        output.gsub! ssn, "[#{filter}]"
       end
 
       Result.new(input, output)

--- a/spec/top_secret_spec.rb
+++ b/spec/top_secret_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe TopSecret::Text do
       input = <<~TEXT
         My email address is user@example.com
         My credit card numbers are 4242-4242-4242-4242 and 4141414141414141
+        My social security number is 123-45-6789
       TEXT
 
       result = TopSecret::Text.filter(input)
@@ -19,6 +20,7 @@ RSpec.describe TopSecret::Text do
       expect(result.output).to eq(<<~TEXT)
         My email address is [EMAIL_1]
         My credit card numbers are [CREDIT_CARD_1] and [CREDIT_CARD_2]
+        My social security number is [SSN_1]
       TEXT
       expect(result.input).to eq(input)
     end
@@ -39,6 +41,12 @@ RSpec.describe TopSecret::Text do
       result = TopSecret::Text.filter("4242424242424242")
 
       expect(result.output).to eq("[CREDIT_CARD_1]")
+    end
+
+    it "filters social security numbers from free text" do
+      result = TopSecret::Text.filter("123-45-6789")
+
+      expect(result.output).to eq("[SSN_1]")
     end
 
     it "returns a TopSecret::Result" do
@@ -108,6 +116,22 @@ RSpec.describe TopSecret::Text do
           [CREDIT_CARD_4]
           [CREDIT_CARD_4]
         TEXT
+      end
+    end
+
+    context "when there are multiple unique social security numbers" do
+      it "filters each social security number from free text" do
+        result = TopSecret::Text.filter("123-45-6789 000-00-0000")
+
+        expect(result.output).to eq("[SSN_1] [SSN_2]")
+      end
+    end
+
+    context "when there are multiple identical social security numbers" do
+      it "filters each social security number from free text, and maps them to the same filter" do
+        result = TopSecret::Text.filter("123-45-6789 123-45-6789")
+
+        expect(result.output).to eq("[SSN_1] [SSN_1]")
       end
     end
   end


### PR DESCRIPTION
Closes #2

For now, this only accounts for delimited numbers to avoid false
positives.

```
123-45-6789
```

We'll want to explore how best to account for non-delimited numbers,
such as:

```
123456789
```
