### PR TITLE
Filter phone numbers from free text

### DIFF
--- a/lib/top_secret.rb
+++ b/lib/top_secret.rb
@@ -7,6 +7,7 @@ module TopSecret
   CREDIT_CARD_REGEX_DELIMITERS = /\b[3456]\d{3}[\s+-]\d{4}[\s+-]\d{4}[\s+-]\d{4}\b/
   # Modified from URI::MailTo::EMAIL_REGEXP
   EMAIL_REGEX = %r{[a-zA-Z0-9.!\#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*}
+  PHONE_REGEX = /\b(?:\+\d{1,2}\s)?\(?\d{3}\)?[\s+.-]\d{3}[\s+.-]\d{4}\b/
   SSN_REGEX = /\b\d{3}[\s+-]\d{2}[\s+-]\d{4}\b/
 
   class Error < StandardError; end
@@ -25,6 +26,7 @@ module TopSecret
       emails = input.scan(EMAIL_REGEX)
       credit_cards = input.scan(CREDIT_CARD_REGEX_DELIMITERS) + input.scan(CREDIT_CARD_REGEX)
       ssns = input.scan(SSN_REGEX)
+      phone_numbers = input.scan(PHONE_REGEX)
 
       emails.uniq.each.with_index(1) do |email, index|
         filter = "EMAIL_#{index}"
@@ -39,6 +41,11 @@ module TopSecret
       ssns.each.with_index(1) do |ssn, index|
         filter = "SSN_#{index}"
         output.gsub! ssn, "[#{filter}]"
+      end
+
+      phone_numbers.each.with_index(1) do |phone_number, index|
+        filter = "PHONE_NUMBER_#{index}"
+        output.gsub! phone_number, "[#{filter}]"
       end
 
       Result.new(input, output)


### PR DESCRIPTION
Closes #11

For now, this matches the following formats.

```
+1 415-555-1234
(415) 555-1234
415.555.1234
415 555 1234
415-555-1234
```

This was lifted from [Logstop][1].

[1]: https://github.com/ankane/logstop/blob/a44fe2d808444f6ad266ae7d3065bce386381619/lib/logstop.rb#L14
