### PR TITLE
Filter people from free text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 # rspec failure tracking
 .rspec_status
+
+# Ignore NER files
+*.dat

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     top_secret (0.1.0)
+      mitie (~> 0.3.2)
 
 GEM
   remote: https://rubygems.org/
@@ -10,6 +11,7 @@ GEM
     date (3.4.1)
     diff-lcs (1.6.2)
     erb (5.0.2)
+    fiddle (1.1.8)
     io-console (0.8.1)
     irb (1.15.2)
       pp (>= 0.6.0)
@@ -18,6 +20,8 @@ GEM
     json (2.13.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
+    mitie (0.3.2)
+      fiddle
     parallel (1.27.0)
     parser (3.3.9.0)
       ast (~> 2.4.1)

--- a/top_secret.gemspec
+++ b/top_secret.gemspec
@@ -31,8 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
+  spec.add_dependency "mitie", "~> 0.3.2"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
Closes #5

Introduces a dependency on [MITIE Ruby][1]. This commit assumes a file
named "ner_model.dat" lives along side the caller, but a future commit
will make this configurable.

Filters "PEOPLE" from free text so long as the "confidence score" is
above a certain threshold. For now, we pick `0.5`, but a future commit
will make this configurable.

Finally, ignore `.dat` files so that we can test locally.

[1]: https://github.com/ankane/mitie-ruby
