### PR TITLE
Filter locations from free text

### DIFF
--- a/lib/top_secret.rb
+++ b/lib/top_secret.rb
@@ -37,6 +37,7 @@ module TopSecret
       build_mapping(phone_numbers, label: "PHONE_NUMBER")
       build_mapping(ssns, label: "SSN")
       build_mapping(people, label: "PERSON")
+      build_mapping(locations, label: "LOCATION")
       substitute_text
 
       Result.new(input, output, mapping)
@@ -77,6 +78,11 @@ module TopSecret
 
     def people
       tags = entities.filter { _1.fetch(:tag) == "PERSON" && _1.fetch(:score) >= MIN_CONFIDENCE_SCORE }
+      tags.map { _1.fetch(:text) }
+    end
+
+    def locations
+      tags = entities.filter { _1.fetch(:tag) == "LOCATION" && _1.fetch(:score) >= MIN_CONFIDENCE_SCORE }
       tags.map { _1.fetch(:text) }
     end
   end


### PR DESCRIPTION
Closes #6

Uses the same logic to filter people that was introduced in #21.

A future commit will allow the caller to configure the confidence score
threshold, but for now, we use `0.5`.
