### PR TITLE
Make NER file location configurable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,16 +2,38 @@ PATH
   remote: .
   specs:
     top_secret (0.1.0)
+      activesupport (~> 8.0, >= 8.0.2)
       mitie (~> 0.3.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (8.0.2)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     ast (2.4.3)
+    base64 (0.3.0)
+    benchmark (0.4.1)
+    bigdecimal (3.2.2)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.3)
     date (3.4.1)
     diff-lcs (1.6.2)
+    drb (2.2.3)
     erb (5.0.2)
     fiddle (1.1.8)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
     io-console (0.8.1)
     irb (1.15.2)
       pp (>= 0.6.0)
@@ -20,6 +42,8 @@ GEM
     json (2.13.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
+    logger (1.7.0)
+    minitest (5.25.5)
     mitie (0.3.2)
       fiddle
     parallel (1.27.0)
@@ -74,6 +98,7 @@ GEM
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.38.0, < 2.0)
     ruby-progressbar (1.13.0)
+    securerandom (0.4.1)
     standard (1.50.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -87,9 +112,12 @@ GEM
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.25.0)
     stringio (3.1.7)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
+    uri (1.0.3)
 
 PLATFORMS
   arm64-darwin-24

--- a/lib/top_secret.rb
+++ b/lib/top_secret.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
 require_relative "top_secret/version"
+require "active_support/configurable"
 require "mitie"
 
 module TopSecret
+  include ActiveSupport::Configurable
+
+  config_accessor :model_path, default: "ner_model.dat"
+
   CREDIT_CARD_REGEX = /\b[3456]\d{15}\b/
   CREDIT_CARD_REGEX_DELIMITERS = /\b[3456]\d{3}[\s+-]\d{4}[\s+-]\d{4}[\s+-]\d{4}\b/
   # Modified from URI::MailTo::EMAIL_REGEXP
@@ -16,19 +21,19 @@ module TopSecret
   class Error < StandardError; end
 
   class Text
-    def initialize(input)
+    def initialize(input, model_path: TopSecret.model_path)
       @input = input
       @output = input.dup
       @mapping = {}
 
       # TODO Make this configurable
-      @model = Mitie::NER.new("ner_model.dat")
+      @model = Mitie::NER.new(model_path)
       @doc = @model.doc(@output)
       @entities = @doc.entities
     end
 
-    def self.filter(input)
-      new(input).filter
+    def self.filter(input, model_path: TopSecret.model_path)
+      new(input, model_path:).filter
     end
 
     def filter

--- a/spec/top_secret_spec.rb
+++ b/spec/top_secret_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe TopSecret do
   it "has a version number" do
     expect(TopSecret::VERSION).not_to be nil
   end
+
+  it "is configurable" do
+    expect(TopSecret.model_path).to eq("ner_model.dat")
+  end
 end
 
 RSpec.describe "TopSecret::PHONE_REGEX" do
@@ -293,6 +297,40 @@ RSpec.describe TopSecret::Text do
         result = TopSecret::Text.filter("Boston")
 
         expect(result.output).to eq("Boston")
+      end
+    end
+  end
+
+  describe "model_path configuration" do
+    before do
+      doc = instance_double("Mitie::Document", entities: [])
+      ner = instance_double("Mitie::NER", doc:)
+      allow(Mitie::NER).to receive(:new).and_return(ner)
+    end
+
+    it "initializes Mitie::NER with the default model_path" do
+      TopSecret::Text.filter("")
+
+      expect(Mitie::NER).to have_received(:new).with(TopSecret.model_path)
+    end
+
+    context "when the model_path is configured" do
+      it "initializes Mitie::NER with model_path" do
+        TopSecret.configure do |config|
+          config.model_path = "custom_path.dat"
+        end
+
+        TopSecret::Text.filter("")
+
+        expect(Mitie::NER).to have_received(:new).with("custom_path.dat")
+      end
+    end
+
+    context "when the model_path is overridden" do
+      it "initializes Mitie::NER with model_path" do
+        TopSecret::Text.filter("", model_path: "custom_path.dat")
+
+        expect(Mitie::NER).to have_received(:new).with("custom_path.dat")
       end
     end
   end

--- a/top_secret.gemspec
+++ b/top_secret.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "activesupport", "~> 8.0", ">= 8.0.2"
   spec.add_dependency "mitie", "~> 0.3.2"
 
   # For more information and examples about making a new gem, check out our


### PR DESCRIPTION
Closes #24

Introduces [`ActiveSupport::Configurable`][1], allowing the Gem to be
configured.

```ruby
TopSecret.configure do |config|
  config.model_path = "custom_path.dat"
end
```

Also introduces `model_path` option so that individual instances can use
different models.

```ruby
TopSecret::Text.filter("Sensitive text", model_path: "custom_path.dat")
```

[1]: https://api.rubyonrails.org/classes/ActiveSupport/Configurable.html
