### PR TITLE
Make confidence score configurable

### DIFF
--- a/lib/top_secret.rb
+++ b/lib/top_secret.rb
@@ -8,6 +8,7 @@ module TopSecret
   include ActiveSupport::Configurable
 
   config_accessor :model_path, default: "ner_model.dat"
+  config_accessor :min_confidence_score, default: 0.5
 
   CREDIT_CARD_REGEX = /\b[3456]\d{15}\b/
   CREDIT_CARD_REGEX_DELIMITERS = /\b[3456]\d{3}[\s+-]\d{4}[\s+-]\d{4}[\s+-]\d{4}\b/
@@ -15,25 +16,23 @@ module TopSecret
   EMAIL_REGEX = %r{[a-zA-Z0-9.!\#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*}
   PHONE_REGEX = /\b(?:\+\d{1,2}\s)?\(?\d{3}\)?[\s+.-]\d{3}[\s+.-]\d{4}\b/
   SSN_REGEX = /\b\d{3}[\s+-]\d{2}[\s+-]\d{4}\b/
-  # TODO Make this configurable
-  MIN_CONFIDENCE_SCORE = 0.5
 
   class Error < StandardError; end
 
   class Text
-    def initialize(input, model_path: TopSecret.model_path)
+    def initialize(input, min_confidence_score: TopSecret.min_confidence_score, model_path: TopSecret.model_path)
       @input = input
       @output = input.dup
       @mapping = {}
 
-      # TODO Make this configurable
       @model = Mitie::NER.new(model_path)
       @doc = @model.doc(@output)
       @entities = @doc.entities
+      @min_confidence_score = min_confidence_score
     end
 
-    def self.filter(input, model_path: TopSecret.model_path)
-      new(input, model_path:).filter
+    def self.filter(input, min_confidence_score: TopSecret.min_confidence_score, model_path: TopSecret.model_path)
+      new(input, model_path:, min_confidence_score:).filter
     end
 
     def filter
@@ -50,7 +49,7 @@ module TopSecret
 
     private
 
-    attr_reader :input, :output, :mapping, :entities
+    attr_reader :input, :output, :mapping, :entities, :min_confidence_score
 
     def build_mapping(values, label:)
       values.uniq.each.with_index(1) do |value, index|
@@ -82,12 +81,12 @@ module TopSecret
     end
 
     def people
-      tags = entities.filter { _1.fetch(:tag) == "PERSON" && _1.fetch(:score) >= MIN_CONFIDENCE_SCORE }
+      tags = entities.filter { _1.fetch(:tag) == "PERSON" && _1.fetch(:score) >= min_confidence_score }
       tags.map { _1.fetch(:text) }
     end
 
     def locations
-      tags = entities.filter { _1.fetch(:tag) == "LOCATION" && _1.fetch(:score) >= MIN_CONFIDENCE_SCORE }
+      tags = entities.filter { _1.fetch(:tag) == "LOCATION" && _1.fetch(:score) >= min_confidence_score }
       tags.map { _1.fetch(:text) }
     end
   end


### PR DESCRIPTION
Closes #23

Give caller the ability to adjust the confidence score threshold when
filtering NER entities.

```ruby
TopSecret.configure do |config|
  configure.min_confidence_score = 0.1
end
```

Additionally, allow caller to pass this as an option.

```ruby
TopSecret::Text.filter("Sensitive information", min_confidence_score: 0.1)
```

This will affect both "People" and "Locations". However, #25 will
explore how individual filters can be overridden, which would allow for
different thresholds for each NER filter.
