### PR TITLE
Support custom filters

### DIFF
--- a/lib/top_secret.rb
+++ b/lib/top_secret.rb
@@ -2,13 +2,11 @@
 
 require_relative "top_secret/version"
 require "active_support/configurable"
+require "active_support/ordered_options"
 require "mitie"
 
 module TopSecret
   include ActiveSupport::Configurable
-
-  config_accessor :model_path, default: "ner_model.dat"
-  config_accessor :min_confidence_score, default: 0.5
 
   CREDIT_CARD_REGEX = /
     \b[3456]\d{15}\b |
@@ -18,11 +16,66 @@ module TopSecret
   EMAIL_REGEX = %r{[a-zA-Z0-9.!\#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*}
   PHONE_REGEX = /\b(?:\+\d{1,2}\s)?\(?\d{3}\)?[\s+.-]\d{3}[\s+.-]\d{4}\b/
   SSN_REGEX = /\b\d{3}[\s+-]\d{2}[\s+-]\d{4}\b/
+  MIN_CONFIDENCE_SCORE = 0.5
+
+  module Filters
+    class Regex
+      attr_reader :label
+
+      def initialize(label:, regex:)
+        @label = label
+        @regex = regex
+      end
+
+      def call(input)
+        input.scan(regex)
+      end
+
+      private
+
+      attr_reader :regex
+    end
+
+    class NER
+      attr_reader :label
+
+      def initialize(label:, tag:, min_confidence_score: nil)
+        @label = label
+        @tag = tag.upcase.to_s
+        @min_confidence_score = min_confidence_score || TopSecret.min_confidence_score
+      end
+
+      def call(entities)
+        tags = entities.filter { _1.fetch(:tag) == tag && _1.fetch(:score) >= min_confidence_score }
+        tags.map { _1.fetch(:text) }
+      end
+
+      private
+
+      attr_reader :tag, :min_confidence_score
+    end
+  end
+
+  config_accessor :model_path, default: "ner_model.dat"
+  config_accessor :min_confidence_score, default: MIN_CONFIDENCE_SCORE
+
+  # TODO: How might we resolve duplicate labels?
+  config_accessor :default_filters do
+    options = ActiveSupport::OrderedOptions.new
+    options.credit_card_filter = TopSecret::Filters::Regex.new(label: "CREDIT_CARD", regex: CREDIT_CARD_REGEX)
+    options.email_filter = TopSecret::Filters::Regex.new(label: "EMAIL", regex: EMAIL_REGEX)
+    options.phone_number_filter = TopSecret::Filters::Regex.new(label: "PHONE_NUMBER", regex: PHONE_REGEX)
+    options.ssn_filter = TopSecret::Filters::Regex.new(label: "SSN", regex: SSN_REGEX)
+    options.people_filter = TopSecret::Filters::NER.new(label: "PERSON", tag: :person)
+    options.location_filter = TopSecret::Filters::NER.new(label: "LOCATION", tag: :location)
+
+    options
+  end
 
   class Error < StandardError; end
 
   class Text
-    def initialize(input)
+    def initialize(input, filters: TopSecret.default_filters)
       @input = input
       @output = input.dup
       @mapping = {}
@@ -30,19 +83,27 @@ module TopSecret
       @model = Mitie::NER.new(TopSecret.model_path)
       @doc = @model.doc(@output)
       @entities = @doc.entities
+
+      @filters = filters
     end
 
-    def self.filter(input)
-      new(input).filter
+    def self.filter(input, filters: {})
+      new(input, filters:).filter
     end
 
     def filter
-      build_mapping(credit_cards, label: "CREDIT_CARD")
-      build_mapping(emails, label: "EMAIL")
-      build_mapping(phone_numbers, label: "PHONE_NUMBER")
-      build_mapping(ssns, label: "SSN")
-      build_mapping(people, label: "PERSON")
-      build_mapping(locations, label: "LOCATION")
+      TopSecret.default_filters.merge(filters).compact.each_value do |filter|
+        values = case filter
+        when TopSecret::Filters::Regex
+          filter.call(input)
+        when TopSecret::Filters::NER
+          filter.call(entities)
+        else
+          raise Error, "Unsupported filter. Expected TopSecret::Filters::Regex or TopSecret::Filters::NER, but got #{filter.class}"
+        end
+        build_mapping(values, label: filter.label)
+      end
+
       substitute_text
 
       Result.new(input, output, mapping)
@@ -50,7 +111,7 @@ module TopSecret
 
     private
 
-    attr_reader :input, :output, :mapping, :entities
+    attr_reader :input, :output, :mapping, :entities, :filters
 
     def build_mapping(values, label:)
       values.uniq.each.with_index(1) do |value, index|
@@ -63,32 +124,6 @@ module TopSecret
       mapping.each do |filter, value|
         output.gsub! value, "[#{filter}]"
       end
-    end
-
-    def credit_cards
-      input.scan(CREDIT_CARD_REGEX)
-    end
-
-    def emails
-      input.scan(EMAIL_REGEX)
-    end
-
-    def phone_numbers
-      input.scan(PHONE_REGEX)
-    end
-
-    def ssns
-      input.scan(SSN_REGEX)
-    end
-
-    def people
-      tags = entities.filter { _1.fetch(:tag) == "PERSON" && _1.fetch(:score) >= TopSecret.min_confidence_score }
-      tags.map { _1.fetch(:text) }
-    end
-
-    def locations
-      tags = entities.filter { _1.fetch(:tag) == "LOCATION" && _1.fetch(:score) >= TopSecret.min_confidence_score }
-      tags.map { _1.fetch(:text) }
     end
   end
 

--- a/spec/top_secret_spec.rb
+++ b/spec/top_secret_spec.rb
@@ -5,9 +5,17 @@ RSpec.describe TopSecret do
     expect(TopSecret::VERSION).not_to be nil
   end
 
-  it "is configurable" do
+  it "has default configuration values" do
     expect(TopSecret.model_path).to eq("ner_model.dat")
     expect(TopSecret.min_confidence_score).to eq(0.5)
+    expect(TopSecret.default_filters).to match(
+      credit_card_filter: an_instance_of(TopSecret::Filters::Regex),
+      email_filter: an_instance_of(TopSecret::Filters::Regex),
+      phone_number_filter: an_instance_of(TopSecret::Filters::Regex),
+      ssn_filter: an_instance_of(TopSecret::Filters::Regex),
+      people_filter: an_instance_of(TopSecret::Filters::NER),
+      location_filter: an_instance_of(TopSecret::Filters::NER)
+    )
   end
 end
 
@@ -18,34 +26,99 @@ RSpec.describe "TopSecret Configuration" do
     allow(Mitie::NER).to receive(:new).and_return(ner)
   end
 
-  it "initializes Mitie::NER with the default model_path" do
+  it "initializes Mitie::NER with the default TopSecret.model_path value" do
     TopSecret::Text.filter("")
 
     expect(Mitie::NER).to have_received(:new).with(TopSecret.model_path)
   end
 
-  context "when the model_path is configured" do
-    it "initializes Mitie::NER with model_path" do
-      with_configuration do
-        TopSecret.configure do |config|
-          config.model_path = "custom_path.dat"
-        end
-
-        TopSecret::Text.filter("")
-
-        expect(Mitie::NER).to have_received(:new).with("custom_path.dat")
+  context "when the TopSecret.model_path configuration is overridden" do
+    it "initializes Mitie::NER with the custom value" do
+      original = TopSecret.model_path
+      TopSecret.configure do |config|
+        config.model_path = "custom_path.dat"
       end
+
+      TopSecret::Text.filter("")
+
+      expect(Mitie::NER).to have_received(:new).with("custom_path.dat")
+    ensure
+      TopSecret.configure { _1.model_path = original }
     end
   end
 
-  def with_configuration
-    original = TopSecret.config.dup
+  it "allows TopSecret.default_filters to be overridden" do
+    original = TopSecret.default_filters.email_filter
 
-    yield
-  ensure
     TopSecret.configure do |config|
-      original.each_pair { |k, v| config.send("#{k}=", v) }
+      config.default_filters.email_filter = TopSecret::Filters::Regex.new(
+        label: "email",
+        regex: /user\[at\]example\.com/
+      )
     end
+
+    result = TopSecret::Text.filter("user[at]example.com")
+
+    expect(result.output).to eq("[email_1]")
+    expect(result.mapping).to eq({
+      email_1: "user[at]example.com"
+    })
+  ensure
+    TopSecret.configure { _1.default_filters.email_filter = original }
+  end
+
+  it "allows TopSecret.default_filters to be ignored" do
+    original = TopSecret.default_filters.email_filter
+
+    TopSecret.configure do |config|
+      config.default_filters.email_filter = nil
+    end
+
+    result = TopSecret::Text.filter("user@example.com")
+
+    expect(result.output).to eq("user@example.com")
+    expect(result.mapping).to eq({})
+  ensure
+    TopSecret.configure { _1.default_filters.email_filter = original }
+  end
+
+  it "respects new regex filters" do
+    TopSecret.configure do |config|
+      config.default_filters.passport = TopSecret::Filters::Regex.new(
+        label: "PASSPORT",
+        regex: /\b[A-Z0-9]{6,9}\b/i
+      )
+    end
+
+    result = TopSecret::Text.filter("A123456")
+
+    expect(result.output).to eq("[PASSPORT_1]")
+    expect(result.mapping).to eq({
+      PASSPORT_1: "A123456"
+    })
+  ensure
+    TopSecret.configure { _1.default_filters.delete(:passport) }
+  end
+
+  it "respects new NER filters" do
+    ip_address = build_entity(text: "192.168.1.1", tag: :ip_address)
+    stub_ner_entities(ip_address)
+
+    TopSecret.configure do |config|
+      config.default_filters.passport = TopSecret::Filters::NER.new(
+        label: "IP_ADDRESS",
+        tag: :ip_address
+      )
+    end
+
+    result = TopSecret::Text.filter("192.168.1.1")
+
+    expect(result.output).to eq("[IP_ADDRESS_1]")
+    expect(result.mapping).to eq({
+      IP_ADDRESS_1: "192.168.1.1"
+    })
+  ensure
+    TopSecret.configure { _1.default_filters.delete(:passport) }
   end
 end
 
@@ -67,9 +140,10 @@ end
 
 RSpec.describe TopSecret::Text do
   describe ".filter" do
+    let(:ralph) { build_entity(text: "Ralph", tag: :person) }
+    let(:boston) { build_entity(text: "Boston", tag: :location) }
+
     before do
-      ralph = build_entity(text: "Ralph", tag: :person)
-      boston = build_entity(text: "Boston", tag: :location)
       stub_ner_entities(ralph, boston)
     end
 
@@ -103,6 +177,203 @@ RSpec.describe TopSecret::Text do
         LOCATION_1: "Boston"
       })
       expect(result.input).to eq(input)
+    end
+
+    context "when the filters option is passed" do
+      it "overrides existing regex filters" do
+        input = <<~TEXT
+          My name is Ralph
+          My location is Boston
+          My email address is user[at]example.com
+          My credit card numbers are 4242-4242-4242-4242 and 4141414141414141
+          My social security number is 123-45-6789
+          My phone number is 555-555-5555
+        TEXT
+
+        result = TopSecret::Text.filter(input, filters: {
+          email_filter: TopSecret::Filters::Regex.new(
+            label: "EMAIL_ADDRESS",
+            regex: /user\[at\]example\.com/
+          )
+        })
+
+        expect(result.output).to eq(<<~TEXT)
+          My name is [PERSON_1]
+          My location is [LOCATION_1]
+          My email address is [EMAIL_ADDRESS_1]
+          My credit card numbers are [CREDIT_CARD_1] and [CREDIT_CARD_2]
+          My social security number is [SSN_1]
+          My phone number is [PHONE_NUMBER_1]
+        TEXT
+        expect(result.mapping).to eq({
+          EMAIL_ADDRESS_1: "user[at]example.com",
+          CREDIT_CARD_1: "4242-4242-4242-4242",
+          CREDIT_CARD_2: "4141414141414141",
+          SSN_1: "123-45-6789",
+          PHONE_NUMBER_1: "555-555-5555",
+          PERSON_1: "Ralph",
+          LOCATION_1: "Boston"
+        })
+        expect(result.input).to eq(input)
+      end
+
+      it "overrides existing NER filters" do
+        score = 0.25
+        ralph = build_entity(text: "Ralph", tag: :person, score:)
+        stub_ner_entities(ralph, boston)
+
+        input = <<~TEXT
+          My name is Ralph
+          My location is Boston
+          My email address is user@example.com
+          My credit card numbers are 4242-4242-4242-4242 and 4141414141414141
+          My social security number is 123-45-6789
+          My phone number is 555-555-5555
+        TEXT
+
+        result = TopSecret::Text.filter(input, filters: {
+          people_filter: TopSecret::Filters::NER.new(
+            label: "NAME",
+            tag: :person,
+            min_confidence_score: score
+          )
+        })
+
+        expect(result.output).to eq(<<~TEXT)
+          My name is [NAME_1]
+          My location is [LOCATION_1]
+          My email address is [EMAIL_1]
+          My credit card numbers are [CREDIT_CARD_1] and [CREDIT_CARD_2]
+          My social security number is [SSN_1]
+          My phone number is [PHONE_NUMBER_1]
+        TEXT
+        expect(result.mapping).to eq({
+          EMAIL_1: "user@example.com",
+          CREDIT_CARD_1: "4242-4242-4242-4242",
+          CREDIT_CARD_2: "4141414141414141",
+          SSN_1: "123-45-6789",
+          PHONE_NUMBER_1: "555-555-5555",
+          NAME_1: "Ralph",
+          LOCATION_1: "Boston"
+        })
+        expect(result.input).to eq(input)
+      end
+
+      it "ignores existing filters" do
+        input = <<~TEXT
+          My name is Ralph
+          My location is Boston
+          My email address is user@example.com
+          My credit card numbers are 4242-4242-4242-4242 and 4141414141414141
+          My social security number is 123-45-6789
+          My phone number is 555-555-5555
+        TEXT
+
+        result = TopSecret::Text.filter(input, filters: {
+          email_filter: nil
+        })
+
+        expect(result.output).to eq(<<~TEXT)
+          My name is [PERSON_1]
+          My location is [LOCATION_1]
+          My email address is user@example.com
+          My credit card numbers are [CREDIT_CARD_1] and [CREDIT_CARD_2]
+          My social security number is [SSN_1]
+          My phone number is [PHONE_NUMBER_1]
+        TEXT
+        expect(result.mapping).to eq({
+          CREDIT_CARD_1: "4242-4242-4242-4242",
+          CREDIT_CARD_2: "4141414141414141",
+          SSN_1: "123-45-6789",
+          PHONE_NUMBER_1: "555-555-5555",
+          PERSON_1: "Ralph",
+          LOCATION_1: "Boston"
+        })
+        expect(result.input).to eq(input)
+      end
+
+      it "respects new regex filters" do
+        input = <<~TEXT
+          My name is Ralph
+          My location is Boston
+          My email address is user@example.com
+          My credit card numbers are 4242-4242-4242-4242 and 4141414141414141
+          My social security number is 123-45-6789
+          My phone number is 555-555-5555
+          My IP address is 192.168.1.1
+        TEXT
+
+        result = TopSecret::Text.filter(input, filters: {
+          ip_address_filter: TopSecret::Filters::Regex.new(
+            label: "IP_ADDRESS",
+            regex: /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/
+          )
+        })
+
+        expect(result.output).to eq(<<~TEXT)
+          My name is [PERSON_1]
+          My location is [LOCATION_1]
+          My email address is [EMAIL_1]
+          My credit card numbers are [CREDIT_CARD_1] and [CREDIT_CARD_2]
+          My social security number is [SSN_1]
+          My phone number is [PHONE_NUMBER_1]
+          My IP address is [IP_ADDRESS_1]
+        TEXT
+        expect(result.mapping).to eq({
+          EMAIL_1: "user@example.com",
+          CREDIT_CARD_1: "4242-4242-4242-4242",
+          CREDIT_CARD_2: "4141414141414141",
+          SSN_1: "123-45-6789",
+          PHONE_NUMBER_1: "555-555-5555",
+          PERSON_1: "Ralph",
+          LOCATION_1: "Boston",
+          IP_ADDRESS_1: "192.168.1.1"
+        })
+        expect(result.input).to eq(input)
+      end
+
+      it "respects new NER filters" do
+        ip_address = build_entity(text: "192.168.1.1", tag: :ip_address)
+        stub_ner_entities(ralph, boston, ip_address)
+
+        input = <<~TEXT
+          My name is Ralph
+          My location is Boston
+          My email address is user@example.com
+          My credit card numbers are 4242-4242-4242-4242 and 4141414141414141
+          My social security number is 123-45-6789
+          My phone number is 555-555-5555
+          My IP address is 192.168.1.1
+        TEXT
+
+        result = TopSecret::Text.filter(input, filters: {
+          ip_address_filter: TopSecret::Filters::NER.new(
+            label: "IP_ADDRESS",
+            tag: :ip_address
+          )
+        })
+
+        expect(result.output).to eq(<<~TEXT)
+          My name is [PERSON_1]
+          My location is [LOCATION_1]
+          My email address is [EMAIL_1]
+          My credit card numbers are [CREDIT_CARD_1] and [CREDIT_CARD_2]
+          My social security number is [SSN_1]
+          My phone number is [PHONE_NUMBER_1]
+          My IP address is [IP_ADDRESS_1]
+        TEXT
+        expect(result.mapping).to eq({
+          EMAIL_1: "user@example.com",
+          CREDIT_CARD_1: "4242-4242-4242-4242",
+          CREDIT_CARD_2: "4141414141414141",
+          SSN_1: "123-45-6789",
+          PHONE_NUMBER_1: "555-555-5555",
+          PERSON_1: "Ralph",
+          LOCATION_1: "Boston",
+          IP_ADDRESS_1: "192.168.1.1"
+        })
+        expect(result.input).to eq(input)
+      end
     end
 
     it "removes duplicate entries from the mapping" do
@@ -339,17 +610,17 @@ RSpec.describe TopSecret::Text do
       end
     end
   end
+end
 
-  private
+private
 
-  def build_entity(text:, tag:, score: TopSecret.min_confidence_score)
-    {text:, tag: tag.to_s.upcase, score:}
-  end
+def build_entity(text:, tag:, score: TopSecret.min_confidence_score)
+  {text:, tag: tag.to_s.upcase, score:}
+end
 
-  def stub_ner_entities(*entities)
-    doc = instance_double("Mitie::Document", entities:)
-    ner = instance_double("Mitie::NER", doc:)
+def stub_ner_entities(*entities)
+  doc = instance_double("Mitie::Document", entities:)
+  ner = instance_double("Mitie::NER", doc:)
 
-    stub_const("Mitie::NER", class_double("Mitie::NER", new: ner))
-  end
+  stub_const("Mitie::NER", class_double("Mitie::NER", new: ner))
 end


### PR DESCRIPTION
Closes #25

This commit allows us to globally override existing filters:

```ruby
TopSecret.configure do |config|
  config.default_filters.email_filter = TopSecret::Filters::Regex.new(label: "EMAIL_ADDRESS", regex: TopSecret::EMAIL_REGEX)
end
```

As well as create new ones:

```ruby
TopSecret.configure do |config|
  config.default_filters.passport = TopSecret::Filters::Regex.new(label: "PASSPORT", regex: /\b[A-Z0-9]{6,9}\b/i)
end

result = TopSecret::Text.filter("A123456") # => #<TopSecret::Result @input="A123456", @mapping={PASSPORT_1: "A123456"}, @output="[PASSPORT_1]">
```

You can also disable a default filter altogether:

```ruby
TopSecret.configure do |config|
  config.default_filters.email_filter = nil
end
```

This commit also supports overriding and creating new filters via a
`filter:` option:

```ruby
TopSecret::Text.filter(input, filters: {
  email_filter: TopSecret::Filters::Regex.new(
    label: "EMAIL_ADDRESS",
    regex: /user\[at\]example\.com/
  )
})

```

You can also ignore a default filter altogether:

```ruby
TopSecret::Text.filter(input, filters: {
  email_filter: nil
}
```
