### PR TITLE
Ensure `min_confidence_score` is respected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+-   Ensure `TopSecret.min_confidence_score` is respected
+
 ## [0.1.0] - 2025-07-23
 
-- Initial release
+-   Initial release

--- a/lib/top_secret/filters/ner.rb
+++ b/lib/top_secret/filters/ner.rb
@@ -13,7 +13,7 @@ module TopSecret
       def initialize(label:, tag:, min_confidence_score: nil)
         @label = label
         @tag = tag.upcase.to_s
-        @min_confidence_score = min_confidence_score || TopSecret.min_confidence_score
+        @min_confidence_score = min_confidence_score
       end
 
       # Filters and extracts entity texts matching the tag and score threshold.
@@ -21,7 +21,7 @@ module TopSecret
       # @param entities [Array<Hash>] List of entity hashes with keys :tag, :score, and :text
       # @return [Array<String>] Matched entity texts
       def call(entities)
-        tags = entities.filter { _1.fetch(:tag) == tag && _1.fetch(:score) >= min_confidence_score }
+        tags = entities.filter { _1.fetch(:tag) == tag && _1.fetch(:score) >= (min_confidence_score || TopSecret.min_confidence_score) }
         tags.map { _1.fetch(:text) }
       end
 

--- a/spec/top_secret_spec.rb
+++ b/spec/top_secret_spec.rb
@@ -32,6 +32,24 @@ RSpec.describe "TopSecret Configuration" do
     expect(Mitie::NER).to have_received(:new).with(TopSecret.model_path)
   end
 
+  it "allows TopSecret.min_confidence_score to be overridden" do
+    original = TopSecret.min_confidence_score
+
+    ralph = build_entity(text: "Ralph", tag: :person, score: 0.5)
+    stub_ner_entities(ralph)
+
+    TopSecret.configure do |config|
+      config.min_confidence_score = 100
+    end
+
+    result = TopSecret::Text.filter("Ralph")
+
+    expect(result.output).to eq("Ralph")
+    expect(result.mapping).to eq({})
+  ensure
+    TopSecret.configure { _1.min_confidence_score = original }
+  end
+
   context "when the TopSecret.model_path configuration is overridden" do
     it "initializes Mitie::NER with the custom value" do
       original = TopSecret.model_path


### PR DESCRIPTION
Closes #38

Prior to this commit, configuring `TopSecret.min_confidence_score` did
not change behavior.

This is because `TopSecret::Filters::NER` were being initialized before
configuring the value.

AI helped debug this issue.
