### PR TITLE
Prepare for `0.1.1` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## [Unreleased]
 
+## [0.1.1] - 2025-08-08
+
 -   Ensure `TopSecret.min_confidence_score` is respected
 
-## [0.1.0] - 2025-07-23
+## [0.1.0] - 2025-08-08
 
 -   Initial release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    top_secret (0.1.0)
+    top_secret (0.1.1)
       activesupport (~> 8.0, >= 8.0.2)
       mitie (~> 0.3.2)
 

--- a/lib/top_secret/version.rb
+++ b/lib/top_secret/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TopSecret
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
Bump version and update CHANGELOG.
