### PR TITLE
Update Ruby Matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,8 @@ jobs:
       matrix:
         ruby:
           - '3.4.5'
+          - '3.3.9'
+          - '3.2.9'
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Inlcude `3.2.9` and `3.3.9`, since those are the latest stable releases.
