### PR TITLE
Breaking Change: Improve filter ergonomics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [Unreleased]
 
+### Changed
+- **BREAKING:** Refactored configuration system to use individual filter accessors instead of nested `default_filters`
+- Updated `TopSecret::Text.filter` to accept keyword arguments for filter overrides and `custom_filters` array
+- Each default filter now has its own configuration accessor (e.g., `TopSecret.email_filter`, `TopSecret.people_filter`)
+
+### Migration Guide
+- Replace `TopSecret.configure { |c| c.default_filters.email_filter = filter }` with `TopSecret.configure { |c| c.email_filter = filter }`
+- Replace `TopSecret::Text.filter(text, filters: { email_filter: filter })` with `TopSecret::Text.filter(text, email_filter: filter)`
+- For new filters, use `TopSecret::Text.filter(text, custom_filters: [filter])` instead of adding to `default_filters`
+
 ## [0.1.1] - 2025-08-08
 
 -   Ensure `TopSecret.min_confidence_score` is respected

--- a/README.md
+++ b/README.md
@@ -166,10 +166,10 @@ When overriding or [disabling](#disabling-a-default-filter-1) a [default filter]
 regex_filter = TopSecret::Filters::Regex.new(label: "EMAIL_ADDRESS", regex: /\b\w+\[at\]\w+\.\w+\b/)
 ner_filter = TopSecret::Filters::NER.new(label: "NAME", tag: :person, min_confidence_score: 0.25)
 
-TopSecret::Text.filter("Ralph can be reached at ralph[at]thoughtbot.com", filters: {
+TopSecret::Text.filter("Ralph can be reached at ralph[at]thoughtbot.com",
   email_filter: regex_filter,
   people_filter: ner_filter
-})
+)
 ```
 
 This will return
@@ -185,10 +185,10 @@ This will return
 #### Disabling a default filter
 
 ```ruby
-TopSecret::Text.filter("Ralph can be reached at ralph@thoughtbot.com", filters: {
+TopSecret::Text.filter("Ralph can be reached at ralph@thoughtbot.com",
   email_filter: nil,
   people_filter: nil
-})
+)
 ```
 
 This will return
@@ -211,9 +211,9 @@ ip_address_filter = TopSecret::Filters::Regex.new(
   regex: /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/
 )
 
-TopSecret::Text.filter("Ralph's IP address is 192.168.1.1", filters: {
-  ip_address_filter: ip_address_filter
-})
+TopSecret::Text.filter("Ralph's IP address is 192.168.1.1",
+  custom_filters: [ip_address_filter]
+)
 ```
 
 This will return
@@ -237,9 +237,9 @@ language_filter = TopSecret::Filters::NER.new(
   min_confidence_score: 0.75
 )
 
-TopSecret::Text.filter("Ralph's favorite programming language is Ruby.", filters: {
-  language_filter: language_filter
-})
+TopSecret::Text.filter("Ralph's favorite programming language is Ruby.",
+  custom_filters: [language_filter]
+)
 ```
 
 This will return
@@ -267,9 +267,9 @@ regex_filter = TopSecret::Filters::Regex.new(
   regex: /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/
 )
 
-result = TopSecret::Text.filter("Server IP: 192.168.1.1", filters: {
-  ip_address_filter: regex_filter
-})
+result = TopSecret::Text.filter("Server IP: 192.168.1.1",
+  custom_filters: [regex_filter]
+)
 
 result.output
 # => "Server IP: [IP_ADDRESS_1]"
@@ -287,9 +287,9 @@ ner_filter = TopSecret::Filters::NER.new(
   min_confidence_score: 0.25
 )
 
-result = TopSecret::Text.filter("Ralph and Ruby work at thoughtbot.", filters: {
+result = TopSecret::Text.filter("Ralph and Ruby work at thoughtbot.",
   people_filter: ner_filter
-})
+)
 
 result.output
 # => "[PERSON_1] and [PERSON_2] work at thoughtbot."
@@ -328,7 +328,7 @@ end
 
 ```ruby
 TopSecret.configure do |config|
-  config.default_filters.email_filter = TopSecret::Filters::Regex.new(
+  config.email_filter = TopSecret::Filters::Regex.new(
     label: "EMAIL_ADDRESS",
     regex: /\b\w+\[at\]\w+\.\w+\b/
   )
@@ -339,7 +339,7 @@ end
 
 ```ruby
 TopSecret.configure do |config|
-  config.default_filters.email_filter = nil
+  config.email_filter = nil
 end
 ```
 
@@ -347,7 +347,7 @@ end
 
 ```ruby
 TopSecret.configure do |config|
-  config.default_filters.ip_address_filter = TopSecret::Filters::Regex.new(
+  config.custom_filters.ip_address_filter = TopSecret::Filters::Regex.new(
     label: "IP_ADDRESS",
     regex: /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/
   )

--- a/lib/top_secret.rb
+++ b/lib/top_secret.rb
@@ -22,23 +22,40 @@ require_relative "top_secret/text"
 # @!attribute [rw] min_confidence_score
 #   @return [Float] the minimum confidence score required for NER matches
 #
-# @!attribute [rw] default_filters
-#   @return [ActiveSupport::OrderedOptions] a set of default filters used to identify sensitive data
+# @!attribute [rw] custom_filters
+#   @return [ActiveSupport::OrderedOptions] a set of custom filters that can be configured
+#
+# @!attribute [rw] credit_card_filter
+#   @return [TopSecret::Filters::Regex] filter for credit card numbers
+#
+# @!attribute [rw] email_filter
+#   @return [TopSecret::Filters::Regex] filter for email addresses
+#
+# @!attribute [rw] phone_number_filter
+#   @return [TopSecret::Filters::Regex] filter for phone numbers
+#
+# @!attribute [rw] ssn_filter
+#   @return [TopSecret::Filters::Regex] filter for social security numbers
+#
+# @!attribute [rw] people_filter
+#   @return [TopSecret::Filters::NER] filter for person names
+#
+# @!attribute [rw] location_filter
+#   @return [TopSecret::Filters::NER] filter for location names
 module TopSecret
   include ActiveSupport::Configurable
 
   config_accessor :model_path, default: "ner_model.dat"
   config_accessor :min_confidence_score, default: MIN_CONFIDENCE_SCORE
 
-  config_accessor :default_filters do
-    options = ActiveSupport::OrderedOptions.new
-    options.credit_card_filter = TopSecret::Filters::Regex.new(label: "CREDIT_CARD", regex: CREDIT_CARD_REGEX)
-    options.email_filter = TopSecret::Filters::Regex.new(label: "EMAIL", regex: EMAIL_REGEX)
-    options.phone_number_filter = TopSecret::Filters::Regex.new(label: "PHONE_NUMBER", regex: PHONE_REGEX)
-    options.ssn_filter = TopSecret::Filters::Regex.new(label: "SSN", regex: SSN_REGEX)
-    options.people_filter = TopSecret::Filters::NER.new(label: "PERSON", tag: :person)
-    options.location_filter = TopSecret::Filters::NER.new(label: "LOCATION", tag: :location)
-
-    options
+  config_accessor :custom_filters do
+    ActiveSupport::OrderedOptions.new
   end
+
+  config_accessor :credit_card_filter, default: TopSecret::Filters::Regex.new(label: "CREDIT_CARD", regex: CREDIT_CARD_REGEX)
+  config_accessor :email_filter, default: TopSecret::Filters::Regex.new(label: "EMAIL", regex: EMAIL_REGEX)
+  config_accessor :phone_number_filter, default: TopSecret::Filters::Regex.new(label: "PHONE_NUMBER", regex: PHONE_REGEX)
+  config_accessor :ssn_filter, default: TopSecret::Filters::Regex.new(label: "SSN", regex: SSN_REGEX)
+  config_accessor :people_filter, default: TopSecret::Filters::NER.new(label: "PERSON", tag: :person)
+  config_accessor :location_filter, default: TopSecret::Filters::NER.new(label: "LOCATION", tag: :location)
 end

--- a/lib/top_secret/text.rb
+++ b/lib/top_secret/text.rb
@@ -5,7 +5,8 @@ module TopSecret
   class Text
     # @param input [String] The original text to be filtered
     # @param filters [Hash, nil] Optional set of filters to override the defaults
-    def initialize(input, filters: TopSecret.default_filters)
+    # @param custom_filters [Array] Additional custom filters to apply
+    def initialize(input, filters: {}, custom_filters: [])
       @input = input
       @output = input.dup
       @mapping = {}
@@ -15,15 +16,17 @@ module TopSecret
       @entities = @doc.entities
 
       @filters = filters
+      @custom_filters = custom_filters || []
     end
 
     # Convenience method to create an instance and filter input
     #
     # @param input [String] The text to filter
     # @param filters [Hash] Optional filters to override defaults
+    # @param custom_filters [Array] Additional custom filters to apply
     # @return [Result] The filtered result
-    def self.filter(input, filters: {})
-      new(input, filters:).filter
+    def self.filter(input, custom_filters: [], **filters)
+      new(input, filters: filters, custom_filters: custom_filters).filter
     end
 
     # Applies configured filters to the input, redacting matches and building a mapping.
@@ -31,7 +34,9 @@ module TopSecret
     # @return [Result] Contains original input, redacted output, and mapping of labels to values
     # @raise [Error] If an unsupported filter is encountered
     def filter
-      TopSecret.default_filters.merge(filters).compact.each_value do |filter|
+      all_filters.each do |filter|
+        next if filter.nil?
+
         values = case filter
         when TopSecret::Filters::Regex
           filter.call(input)
@@ -65,6 +70,9 @@ module TopSecret
     # @return [Hash] Active filters used for redaction
     attr_reader :filters
 
+    # @return [Array] Custom filters to apply
+    attr_reader :custom_filters
+
     # Builds the mapping of label keys to matched values, indexed uniquely.
     #
     # @param values [Array<String>] Values matched by a filter
@@ -84,6 +92,27 @@ module TopSecret
       mapping.each do |filter, value|
         output.gsub! value, "[#{filter}]"
       end
+    end
+
+    # Collects all filters to apply: default filters with overrides plus custom filters
+    #
+    # @return [Array] Array of filter objects to apply
+    def all_filters
+      # Get current default filters
+      default_filters = {
+        credit_card_filter: TopSecret.credit_card_filter,
+        email_filter: TopSecret.email_filter,
+        phone_number_filter: TopSecret.phone_number_filter,
+        ssn_filter: TopSecret.ssn_filter,
+        people_filter: TopSecret.people_filter,
+        location_filter: TopSecret.location_filter
+      }
+
+      # Apply any overrides from the filters parameter
+      merged_filters = default_filters.merge(filters)
+
+      # Combine default/override filters with custom filters
+      merged_filters.values.compact + custom_filters
     end
   end
 end

--- a/spec/top_secret/text_spec.rb
+++ b/spec/top_secret/text_spec.rb
@@ -52,12 +52,10 @@ RSpec.describe TopSecret::Text do
           My phone number is 555-555-5555
         TEXT
 
-        result = TopSecret::Text.filter(input, filters: {
-          email_filter: TopSecret::Filters::Regex.new(
-            label: "EMAIL_ADDRESS",
-            regex: /user\[at\]example\.com/
-          )
-        })
+        result = TopSecret::Text.filter(input, email_filter: TopSecret::Filters::Regex.new(
+          label: "EMAIL_ADDRESS",
+          regex: /user\[at\]example\.com/
+        ))
 
         expect(result.output).to eq(<<~TEXT)
           My name is [PERSON_1]
@@ -93,13 +91,11 @@ RSpec.describe TopSecret::Text do
           My phone number is 555-555-5555
         TEXT
 
-        result = TopSecret::Text.filter(input, filters: {
-          people_filter: TopSecret::Filters::NER.new(
-            label: "NAME",
-            tag: :person,
-            min_confidence_score: score
-          )
-        })
+        result = TopSecret::Text.filter(input, people_filter: TopSecret::Filters::NER.new(
+          label: "NAME",
+          tag: :person,
+          min_confidence_score: score
+        ))
 
         expect(result.output).to eq(<<~TEXT)
           My name is [NAME_1]
@@ -131,9 +127,7 @@ RSpec.describe TopSecret::Text do
           My phone number is 555-555-5555
         TEXT
 
-        result = TopSecret::Text.filter(input, filters: {
-          email_filter: nil
-        })
+        result = TopSecret::Text.filter(input, email_filter: nil)
 
         expect(result.output).to eq(<<~TEXT)
           My name is [PERSON_1]
@@ -165,12 +159,10 @@ RSpec.describe TopSecret::Text do
           My IP address is 192.168.1.1
         TEXT
 
-        result = TopSecret::Text.filter(input, filters: {
-          ip_address_filter: TopSecret::Filters::Regex.new(
-            label: "IP_ADDRESS",
-            regex: /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/
-          )
-        })
+        result = TopSecret::Text.filter(input, custom_filters: [TopSecret::Filters::Regex.new(
+          label: "IP_ADDRESS",
+          regex: /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/
+        )])
 
         expect(result.output).to eq(<<~TEXT)
           My name is [PERSON_1]
@@ -208,12 +200,10 @@ RSpec.describe TopSecret::Text do
           My IP address is 192.168.1.1
         TEXT
 
-        result = TopSecret::Text.filter(input, filters: {
-          ip_address_filter: TopSecret::Filters::NER.new(
-            label: "IP_ADDRESS",
-            tag: :ip_address
-          )
-        })
+        result = TopSecret::Text.filter(input, custom_filters: [TopSecret::Filters::NER.new(
+          label: "IP_ADDRESS",
+          tag: :ip_address
+        )])
 
         expect(result.output).to eq(<<~TEXT)
           My name is [PERSON_1]


### PR DESCRIPTION
Relates to this [discussion][1].

It can be cumbersome and brittle to ensure the filter keys matches an
existing default filter. For example:

```ruby
new_email_filter = TopSecret::Filters::Regex.new(label: "EMAIL_ADDRESS", regex: /\b\w+\[at\]\w+\.\w+\b/)

TopSecret::Text.filter("Ralph can be reached at ralph[at]thoughtbot.com", filters: {
  email_filter: new_email_filter,
})
```

There are a few problems with this approach:

1. You need to know what the default filters are.
2. You could accidentally create a new filter instead of overriding one (see below)

```ruby
new_email_filter = TopSecret::Filters::Regex.new(label: "EMAIL_ADDRESS", regex: /\b\w+\[at\]\w+\.\w+\b/)

TopSecret::Text.filter("Ralph can be reached at ralph[at]thoughtbot.com", filters: {
  # Note the typo
  email_fillter: new_email_filter,
})
```

This commit (which was made via Claude Code, and guided by the
[example][2] in the discussion) updates the method signature for
`TopSecret::Text.filter`, as well as changes the configuration API.

[1]: https://github.com/thoughtbot/top_secret/discussions/52
[2]: https://github.com/thoughtbot/top_secret/discussions/52#discussioncomment-14096235
