### PR TITLE
Introduce `TopSecret::Text.filter_all`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Added
+
+-   Added `TopSecret::Text.filter_all` for batch processing multiple messages with globally consistent redaction labels
+-   Added `TopSecret::BatchResult` class to hold results from batch operations
+
 ### Changed
 
 -   **BREAKING:** Refactored configuration system to use individual filter accessors instead of nested `default_filters`

--- a/README.md
+++ b/README.md
@@ -156,6 +156,53 @@ result.mapping
 # => {:EMAIL_1=>"ralph@thoughtbot.com", :PERSON_1=>"Ralph"}
 ```
 
+### Batch Processing
+
+When processing multiple messages, use `filter_all` to ensure consistent redaction labels across all messages:
+
+```ruby
+messages = [
+  "Contact ralph@thoughtbot.com for details",
+  "Email ralph@thoughtbot.com again if needed",
+  "Also CC ruby@thoughtbot.com on the thread"
+]
+
+result = TopSecret::Text.filter_all(messages)
+```
+
+This will return
+
+```ruby
+<TopSecret::BatchResult
+  @mapping={:EMAIL_1=>"ralph@thoughtbot.com", :EMAIL_2=>"ruby@thoughtbot.com"},
+  @items=[
+    <TopSecret::BatchResult::Item @input="Contact ralph@thoughtbot.com for details", @output="Contact [EMAIL_1] for details">,
+    <TopSecret::BatchResult::Item @input="Email ralph@thoughtbot.com again if needed", @output="Email [EMAIL_1] again if needed">,
+    <TopSecret::BatchResult::Item @input="Also CC ruby@thoughtbot.com on the thread", @output="Also CC [EMAIL_2] on the thread">
+  ]
+>
+```
+
+Access the global mapping
+
+```ruby
+result.mapping
+
+# => {:EMAIL_1=>"ralph@thoughtbot.com", :EMAIL_2=>"ruby@thoughtbot.com"}
+```
+
+Access individual items
+
+```ruby
+result.items[0].input
+# => "Contact ralph@thoughtbot.com for details"
+
+result.items[0].output
+# => "Contact [EMAIL_1] for details"
+```
+
+The key benefit is that identical values receive the same labels across all messages - notice how `ralph@thoughtbot.com` becomes `[EMAIL_1]` in both the first and second messages.
+
 ### Advanced Examples
 
 #### Overriding the default filters

--- a/lib/top_secret.rb
+++ b/lib/top_secret.rb
@@ -11,6 +11,7 @@ require_relative "top_secret/constants"
 require_relative "top_secret/filters/ner"
 require_relative "top_secret/filters/regex"
 require_relative "top_secret/error"
+require_relative "top_secret/batch_result"
 require_relative "top_secret/result"
 require_relative "top_secret/text"
 

--- a/lib/top_secret/batch_result.rb
+++ b/lib/top_secret/batch_result.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module TopSecret
+  # Holds the result of a batch redaction operation on multiple messages.
+  # Contains a global mapping that ensures consistent labeling across all messages
+  # and a collection of individual input/output pairs.
+  class BatchResult
+    # @return [Hash] Global mapping of redaction labels to original values across all messages
+    attr_reader :mapping
+
+    # @return [Array<Item>] Array of input/output pairs for each processed message
+    attr_reader :items
+
+    # Creates a new BatchResult instance
+    #
+    # @param mapping [Hash] Global mapping of redaction labels to original values
+    # @param items [Array<Item>] Array of input/output pairs
+    def initialize(mapping: {}, items: [])
+      @mapping = mapping
+      @items = items
+    end
+
+    # Represents a single message within a batch redaction operation.
+    # Contains only the input and output text, without individual mappings.
+    # The mapping is maintained at the BatchResult level for global consistency.
+    class Item
+      # @return [String] The original unredacted input
+      attr_reader :input
+
+      # @return [String] The redacted output
+      attr_reader :output
+
+      # Creates a new Item instance
+      #
+      # @param input [String] The original text
+      # @param output [String] The redacted text
+      def initialize(input, output)
+        @input = input
+        @output = output
+      end
+    end
+  end
+end

--- a/lib/top_secret/text.rb
+++ b/lib/top_secret/text.rb
@@ -56,15 +56,12 @@ module TopSecret
     #   ip_filter = TopSecret::Filters::Regex.new(label: "IP", regex: /\d+\.\d+\.\d+\.\d+/)
     #   result = TopSecret::Text.filter_all(messages, custom_filters: [ip_filter])
     def self.filter_all(messages, custom_filters: [], **filters)
-      # Create shared model once for performance
       shared_model = Mitie::NER.new(TopSecret.model_path)
 
-      # First pass: collect all individual results using shared model
       individual_results = messages.map do |message|
         new(message, filters:, custom_filters:, model: shared_model).filter
       end
 
-      # Build global mapping tracking order of first occurrence across all messages
       global_mapping = {}
       label_counters = {}
 

--- a/lib/top_secret/text.rb
+++ b/lib/top_secret/text.rb
@@ -79,10 +79,11 @@ module TopSecret
         end
       end
 
+      inverted_global_mapping = global_mapping.invert
+
       items = individual_results.map do |result|
         output = result.input.dup
-        global_mapping.invert.each { |filter, value| output.gsub!(value, "[#{filter}]") }
-
+        inverted_global_mapping.each { |filter, value| output.gsub!(value, "[#{filter}]") }
         BatchResult::Item.new(result.input, output)
       end
 


### PR DESCRIPTION
Relates to this [discussion][1].

In an effort to filter [conversation state][2] when working with LLMs,
we introduce `TopSecret::Text.filter_all`. This allows us to filter an
Array-like set of messages, while ensuring the mapping is used
consistently throughout each message.

Prior to this commit, you would have needed to call
`TopSecret::Text.filter` on each message. which would have resulted in
inconsistent mapping.

When testing local, I noticed the method was slow. Claude Code wrote some
benchmarks for me, and identified the issue was the fact that we were
initializing `Mitie::NER` for **each** message. After some back-and-forth, we
landed on a solution that introduced dependency injection. This way, we can
initialize `Mitie::NER` just once.

A future commit will introduce a benchmark script and CI step.

[1]: https://github.com/thoughtbot/top_secret/discussions/47
[2]: https://platform.openai.com/docs/guides/conversation-state?api-mode=responses
