### PR TITLE
Add benchmark tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,17 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 >
 > You'll need to download and extract [ner_model.dat][] first, and place it in the root of this project.
 
+### Performance Benchmarks
+
+Run `bin/benchmark` to test performance and catch regressions:
+
+```bash
+bin/benchmark  # CI-optimized benchmark with pass/fail thresholds
+```
+
+> [!NOTE]
+> When adding new public methods to the API, ensure they are included in the benchmark script to catch performance regressions.
+
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -1,0 +1,70 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# CI Performance Benchmark - optimized for automated testing
+require "bundler/setup"
+require "benchmark"
+require_relative "../lib/top_secret"
+
+# CI-optimized configuration
+ITERATIONS = 3
+WARMUP_ITERATIONS = 1  
+MAX_TIME_PER_MESSAGE_MS = 350
+MIN_SPEEDUP = 2.5
+
+# Small but representative test set
+TEST_MESSAGES = [
+  "Contact john@test.com with card 4242424242424242",
+  "Email ruby@example.org about 4141414141414141", 
+  "Call john@test.com regarding 4242424242424242"
+].freeze
+
+puts "=== Performance Benchmark ==="
+
+# Warmup
+WARMUP_ITERATIONS.times { TopSecret::Text.filter_all(TEST_MESSAGES) }
+
+# Benchmark individual calls
+individual_times = []
+ITERATIONS.times do
+  start = Time.now
+  TEST_MESSAGES.each { |msg| TopSecret::Text.filter(msg) }
+  individual_times << Time.now - start
+end
+
+# Benchmark batch calls
+batch_times = []
+ITERATIONS.times do
+  start = Time.now
+  TopSecret::Text.filter_all(TEST_MESSAGES)
+  batch_times << Time.now - start
+end
+
+# Calculate results
+avg_individual = individual_times.sum / ITERATIONS
+avg_batch = batch_times.sum / ITERATIONS
+speedup = avg_individual / avg_batch
+per_message_ms = (avg_batch / TEST_MESSAGES.size) * 1000
+
+puts "Batch time: #{(avg_batch * 1000).round(2)}ms"
+puts "Per message: #{per_message_ms.round(2)}ms"  
+puts "Speedup: #{speedup.round(2)}x"
+
+# Validation
+exit_code = 0
+
+if per_message_ms > MAX_TIME_PER_MESSAGE_MS
+  puts "❌ Performance regression: #{per_message_ms.round(2)}ms > #{MAX_TIME_PER_MESSAGE_MS}ms"
+  exit_code = 1
+end
+
+if speedup < MIN_SPEEDUP
+  puts "❌ Speedup regression: #{speedup.round(2)}x < #{MIN_SPEEDUP}x"  
+  exit_code = 1
+end
+
+if exit_code == 0
+  puts "✅ Performance benchmarks passed"
+end
+
+exit exit_code


### PR DESCRIPTION
While working on #54, I discovered a serious performance issue during
local development. Fortunately I caught it, and worked with Claude Code
to diagnose the problem and implement a solution.

In an effort to catch performance regressions, as well as catch new
performance issues, we introduce `bin/benchmark`

For the time being, this cannot be run in CI because it depends on
`ner_model.dat` existing in root of the project.

It should be noted that `bin/benchmark` will need to be updated each time
a new method is added that we want to test. For now, it will simply
catch regressions.
