### PR TITLE
Introduce `TopSecret::FilteredText.restore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 -   Added `TopSecret::Text.filter_all` for batch processing multiple messages with globally consistent redaction labels
 -   Added `TopSecret::BatchResult` class to hold results from batch operations
+-   Added `TopSecret::FilteredText` class for restoring filtered text by substituting placeholders with original values
+-   Added `TopSecret::FilteredText::Result` class to track restoration success and failures
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,52 @@ result.items[0].output
 
 The key benefit is that identical values receive the same labels across all messages - notice how `ralph@thoughtbot.com` becomes `[EMAIL_1]` in both the first and second messages.
 
+### Restoring Filtered Text
+
+When external services (like LLMs) return responses containing filter placeholders, use `TopSecret::FilteredText.restore` to substitute them back with original values:
+
+```ruby
+# Filter messages before sending to LLM
+messages = ["Contact ralph@thoughtbot.com for details"]
+batch_result = TopSecret::Text.filter_all(messages)
+
+# Send filtered text to LLM: "Contact [EMAIL_1] for details"
+# LLM responds with: "I'll email [EMAIL_1] about this request"
+llm_response = "I'll email [EMAIL_1] about this request"
+
+# Restore the original values
+restore_result = TopSecret::FilteredText.restore(llm_response, mapping: batch_result.mapping)
+```
+
+This will return
+
+```ruby
+<TopSecret::FilteredText::Result
+  @output="I'll email ralph@thoughtbot.com about this request",
+  @restored=["[EMAIL_1]"],
+  @unrestored=[]
+>
+```
+
+Access the restored text
+
+```ruby
+restore_result.output
+# => "I'll email ralph@thoughtbot.com about this request"
+```
+
+Track which placeholders were restored
+
+```ruby
+restore_result.restored
+# => ["[EMAIL_1]"]
+
+restore_result.unrestored
+# => []
+```
+
+The restoration process tracks both successful and failed placeholder substitutions, allowing you to handle cases where the LLM response contains placeholders not found in your mapping.
+
 ### Advanced Examples
 
 #### Overriding the default filters

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -40,14 +40,27 @@ ITERATIONS.times do
   batch_times << Time.now - start
 end
 
+# Benchmark restoration calls
+restore_times = []
+batch_result = TopSecret::Text.filter_all(TEST_MESSAGES)
+test_response = "Contact [EMAIL_1] about [CREDIT_CARD_1] issue"
+ITERATIONS.times do
+  start = Time.now
+  TopSecret::FilteredText.restore(test_response, mapping: batch_result.mapping)
+  restore_times << Time.now - start
+end
+
 # Calculate results
 avg_individual = individual_times.sum / ITERATIONS
 avg_batch = batch_times.sum / ITERATIONS
+avg_restore = restore_times.sum / ITERATIONS
 speedup = avg_individual / avg_batch
 per_message_ms = (avg_batch / TEST_MESSAGES.size) * 1000
+restore_ms = avg_restore * 1000
 
 puts "Batch time: #{(avg_batch * 1000).round(2)}ms"
 puts "Per message: #{per_message_ms.round(2)}ms"  
+puts "Restore time: #{restore_ms.round(2)}ms"
 puts "Speedup: #{speedup.round(2)}x"
 
 # Validation

--- a/lib/top_secret.rb
+++ b/lib/top_secret.rb
@@ -14,6 +14,7 @@ require_relative "top_secret/error"
 require_relative "top_secret/batch_result"
 require_relative "top_secret/result"
 require_relative "top_secret/text"
+require_relative "top_secret/filtered_text"
 
 # TopSecret filters sensitive information from free text before it's sent to external services or APIs, such as chatbots and LLMs.
 #

--- a/lib/top_secret/filtered_text.rb
+++ b/lib/top_secret/filtered_text.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require_relative "filtered_text/result"
+
+module TopSecret
+  # Restores filtered text by substituting placeholders with original values.
+  #
+  # This class is used to reverse the filtering process, typically when processing
+  # responses from external services like LLMs that may contain filtered placeholders.
+  class FilteredText
+    # @return [String] The text being processed for restoration
+    attr_reader :output
+
+    # @param filtered_text [String] Text containing filter placeholders like [EMAIL_1]
+    # @param mapping [Hash] Hash mapping filter symbols to original values
+    def initialize(filtered_text, mapping:)
+      @mapping = mapping
+      @output = filtered_text.dup
+    end
+
+    # Convenience method to restore filtered text in one call
+    #
+    # @param filtered_text [String] Text containing filter placeholders
+    # @param mapping [Hash] Hash mapping filter symbols to original values
+    # @return [Result] Contains restored text and tracking information
+    #
+    # @example Basic restoration
+    #   mapping = {EMAIL_1: "john@example.com"}
+    #   result = TopSecret::FilteredText.restore("Contact [EMAIL_1]", mapping: mapping)
+    #   result.output # => "Contact john@example.com"
+    #   result.restored # => ["[EMAIL_1]"]
+    #   result.unrestored # => []
+    def self.restore(filtered_text, mapping:)
+      new(filtered_text, mapping:).restore
+    end
+
+    # Performs the restoration process
+    #
+    # Substitutes all found placeholders with their mapped values and tracks
+    # which placeholders were successfully restored vs those that remain unrestored.
+    #
+    # @return [Result] Contains the restored text and tracking arrays
+    def restore
+      restored = []
+
+      mapping.each do |filter, value|
+        placeholder = build_placeholder(filter)
+
+        if output.include? placeholder
+          restored << placeholder
+          output.gsub! placeholder, value
+        end
+      end
+
+      unrestored = output.scan(/\[\w*_\d\]/)
+
+      Result.new(output, unrestored, restored)
+    end
+
+    private
+
+    # @return [Hash] Mapping from filter symbols to original values
+    attr_reader :mapping
+
+    # Builds a placeholder string from a filter symbol
+    #
+    # @param filter [Symbol] The filter symbol (e.g., :EMAIL_1)
+    # @return [String] The placeholder string (e.g., "[EMAIL_1]")
+    def build_placeholder(filter)
+      "[#{filter}]"
+    end
+  end
+end

--- a/lib/top_secret/filtered_text/result.rb
+++ b/lib/top_secret/filtered_text/result.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module TopSecret
+  class FilteredText
+    # Result object returned by FilteredText restoration operations.
+    #
+    # Contains the restored text along with tracking information about which
+    # placeholders were successfully restored and which remain unrestored.
+    class Result
+      # @return [String] The text with placeholders restored to original values
+      attr_reader :output
+
+      # @return [Array<String>] Array of placeholder strings that could not be restored
+      attr_reader :unrestored
+
+      # @return [Array<String>] Array of placeholder strings that were successfully restored
+      attr_reader :restored
+
+      # @param output [String] The restored text
+      # @param unrestored [Array<String>] Placeholders that could not be restored
+      # @param restored [Array<String>] Placeholders that were successfully restored
+      def initialize(output, unrestored, restored)
+        @output = output
+        @unrestored = unrestored
+        @restored = restored
+      end
+    end
+  end
+end

--- a/spec/top_secret/filtered_text_spec.rb
+++ b/spec/top_secret/filtered_text_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+RSpec.describe TopSecret::FilteredText do
+  describe ".restore" do
+    it "restores filtered text from a mapping" do
+      person = "Ralph"
+      mapping = {PERSON_1: person}
+      llm_response = "Hello, [PERSON_1]!"
+
+      result = TopSecret::FilteredText.restore(llm_response, mapping:)
+
+      expect(result.output).to eq("Hello, #{person}!")
+      expect(result.unrestored).to eq([])
+      expect(result.restored).to eq(["[PERSON_1]"])
+    end
+
+    context "when a filter has multiple underscores" do
+      it "restores filtered text from a mapping" do
+        person = "Ralph"
+        mapping = {PERSON_NAME_1: person}
+        llm_response = "Hello, [PERSON_NAME_1]!"
+
+        result = TopSecret::FilteredText.restore(llm_response, mapping:)
+
+        expect(result.output).to eq("Hello, #{person}!")
+        expect(result.unrestored).to eq([])
+        expect(result.restored).to eq(["[PERSON_NAME_1]"])
+      end
+    end
+
+    context "when a filter has multiple digits" do
+      it "restores filtered text from a mapping" do
+        person = "Ralph"
+        mapping = {PERSON_NAME_1_1: person}
+        llm_response = "Hello, [PERSON_NAME_1_1]!"
+
+        result = TopSecret::FilteredText.restore(llm_response, mapping:)
+
+        expect(result.output).to eq("Hello, #{person}!")
+        expect(result.unrestored).to eq([])
+        expect(result.restored).to eq(["[PERSON_NAME_1_1]"])
+      end
+    end
+
+    context "when the filter does not have the same casing" do
+      it "does not restore filtered text from a mapping" do
+        person = "Ralph"
+        mapping = {PERSON_1: person}
+        llm_response = "Hello, [person_1]!"
+
+        result = TopSecret::FilteredText.restore(llm_response, mapping:)
+
+        expect(result.output).to eq(llm_response)
+        expect(result.unrestored).to eq(["[person_1]"])
+        expect(result.restored).to eq([])
+      end
+    end
+
+    context "when there are no matches" do
+      it "returns a list of filters that could not be restored" do
+        mapping = {EMAIL_1: "ralph@example.com"}
+        llm_response = "Hello, [PERSON_1]!"
+
+        result = TopSecret::FilteredText.restore(llm_response, mapping:)
+
+        expect(result.output).to eq(llm_response)
+        expect(result.unrestored).to eq(["[PERSON_1]"])
+        expect(result.restored).to eq([])
+      end
+    end
+
+    context "when there are partial matches" do
+      it "returns a list of filters that could not be restored" do
+        email = "ralph@example.com"
+        mapping = {EMAIL_1: email}
+        llm_response = "Hello, [PERSON_1]! I'll email you at [EMAIL_1]."
+
+        result = TopSecret::FilteredText.restore(llm_response, mapping:)
+
+        expect(result.output).to eq("Hello, [PERSON_1]! I'll email you at #{email}.")
+        expect(result.unrestored).to eq(["[PERSON_1]"])
+        expect(result.restored).to eq(["[EMAIL_1]"])
+      end
+    end
+
+    context "when the same filter appears multiple times" do
+      it "does not duplicate filters in the restored list" do
+        person = "Ralph"
+        mapping = {PERSON_1: person}
+        llm_response = "Hello, [PERSON_1]! Nice to meet you, [PERSON_1]."
+
+        result = TopSecret::FilteredText.restore(llm_response, mapping:)
+
+        expect(result.output).to eq("Hello, #{person}! Nice to meet you, #{person}.")
+        expect(result.unrestored).to eq([])
+        expect(result.restored).to eq(["[PERSON_1]"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
When external services (like LLMs) return responses containing filter
placeholders, use `TopSecret::FilteredText.restore` to substitute them back with
original values:

```ruby
# Filter messages before sending to LLM
messages = ["Contact ralph@thoughtbot.com for details"]
batch_result = TopSecret::Text.filter_all(messages)

# Send filtered text to LLM: "Contact [EMAIL_1] for details"
# LLM responds with: "I'll email [EMAIL_1] about this request"
llm_response = "I'll email [EMAIL_1] about this request"

# Restore the original values
restore_result = TopSecret::FilteredText.restore(llm_response, mapping: batch_result.mapping)
```

This will return

```ruby
<TopSecret::FilteredText::Result
  @output="I'll email ralph@thoughtbot.com about this request",
  @restored=["[EMAIL_1]"],
  @unrestored=[]
>
```

Access the restored text

```ruby
restore_result.output
# => "I'll email ralph@thoughtbot.com about this request"
```

Track which placeholders were restored

```ruby
restore_result.restored
# => ["[EMAIL_1]"]

restore_result.unrestored
# => []
```

The restoration process tracks both successful and failed placeholder
substitutions, allowing you to handle cases where the LLM response contains
placeholders not found in your mapping.

We introduce `TopSecret::FilteredText::Result` because there is already
`TopSecret::Result`. A follow-up commit will move that to the `TopSecret::Text`
namespace.
