### PR TITLE
Prepare for `0.2.0` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [0.2.0] - 2025-08-18
+
 ### Added
 
 -   Added `TopSecret::Text.filter_all` for batch processing multiple messages with globally consistent redaction labels

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    top_secret (0.1.1)
+    top_secret (0.2.0)
       activesupport (~> 8.0, >= 8.0.2)
       mitie (~> 0.3.2)
 

--- a/lib/top_secret/version.rb
+++ b/lib/top_secret/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TopSecret
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
Since there are several breaking changes, we bump to the next minor
version.
