### PR TITLE
Allow NER filtering to be disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## [Unreleased]
 
+### Added
+
+-   Added support for disabling NER filtering by setting `model_path` to `nil` for improved performance and deployment flexibility
+
+### Changed
+
+-   Improved performance by implementing lazy loading of MITIE model and document processing
+-   NER filtering now gracefully falls back when MITIE model is unavailable, continuing with regex-based filters only
+
 ## [0.2.0] - 2025-08-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ gem install top_secret
 > Due to its large size, you'll likely want to avoid committing [ner_model.dat][] into version control.
 >
 > You'll need to ensure the file exists in deployed environments. See relevant [discussion][discussions_60] for details.
+>
+> Alternatively, you can disable NER filtering entirely by setting `model_path` to `nil` if you only need regex-based filters (credit cards, emails, phone numbers, SSNs). This improves performance and eliminates the model file dependency.
 
 By default, Top Secret assumes the file will live at the root of your project, but this can be configured.
 
@@ -479,6 +481,22 @@ TopSecret.configure do |config|
   config.model_path = "path/to/ner_model.dat"
 end
 ```
+
+### Disabling NER filtering
+
+For improved performance or when the MITIE model file cannot be deployed, you can disable NER-based filtering entirely. This will disable people and location detection but retain all regex-based filters (credit cards, emails, phone numbers, SSNs):
+
+```ruby
+TopSecret.configure do |config|
+  config.model_path = nil
+end
+```
+
+This is useful in environments where:
+
+-   The model file cannot be deployed due to size constraints
+-   You only need regex-based filtering
+-   You want to optimize for performance over NER capabilities
 
 ### Overriding the confidence score
 

--- a/lib/top_secret/null_model.rb
+++ b/lib/top_secret/null_model.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module TopSecret
+  # A null object implementation that provides a no-op interface compatible with Mitie::NER.
+  # Used when NER filtering is disabled (model_path is nil) to eliminate conditional checks
+  # throughout the codebase.
+  #
+  # @example
+  #   model = TopSecret::NullModel.new
+  #   doc = model.doc("some text")
+  #   doc.entities # => []
+  class NullModel
+    # A null document implementation that provides an empty entities array.
+    # Used as the return value from NullModel#doc to maintain interface compatibility.
+    class NullDoc
+      # Returns an empty array of entities.
+      #
+      # @return [Array] Always returns an empty array
+      def entities
+        []
+      end
+    end
+
+    # Creates a null document that returns empty entities.
+    #
+    # @param input [String] The input text (ignored)
+    # @return [NullDoc] A document-like object with empty entities
+    def doc(input)
+      NullDoc.new
+    end
+  end
+end


### PR DESCRIPTION
Relates to this [discussion][1].

NER filtering can be expensive, and requires training data to exist in deployed
environments. Because of this, it may not be possible or practical to use it.
This commit allows those filters to be ignored by setting `TopSecret.model_path`
to `nil`.

[1]: https://github.com/thoughtbot/top_secret/discussions/61
