### PR TITLE
Introduce `TopSecret::Text.scan`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+-   Added `TopSecret::Text.scan` method for detecting sensitive information without redacting text
+-   Added `TopSecret::Text::ScanResult` class to hold scan operation results with `mapping` and `sensitive?` methods
 -   Added support for disabling NER filtering by setting `model_path` to `nil` for improved performance and deployment flexibility
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -163,6 +163,65 @@ result.mapping
 # => {:EMAIL_1=>"ralph@thoughtbot.com", :PERSON_1=>"Ralph"}
 ```
 
+### Scanning for Sensitive Information
+
+Use `TopSecret::Text.scan` to detect sensitive information without redacting the text. This is useful when you only need to check if sensitive data exists or get a mapping of what was found:
+
+```ruby
+TopSecret::Text.scan("Ralph can be reached at ralph@thoughtbot.com")
+```
+
+This will return
+
+```ruby
+<TopSecret::Text::ScanResult
+  @mapping={:EMAIL_1=>"ralph@thoughtbot.com", :PERSON_1=>"Ralph"}
+>
+```
+
+Check if sensitive information was found
+
+```ruby
+result.sensitive?
+
+# => true
+```
+
+View the mapping of found sensitive information
+
+```ruby
+result.mapping
+
+# => {:EMAIL_1=>"ralph@thoughtbot.com", :PERSON_1=>"Ralph"}
+```
+
+The `scan` method accepts the same filter options as `filter`:
+
+```ruby
+# Override default filters
+email_filter =  TopSecret::Filters::Regex.new(
+  label: "EMAIL_ADDRESS",
+  regex: /\w+\[at\]\w+\.\w+/
+)
+result = TopSecret::Text.scan("Contact user[at]example.com", email_filter:)
+result.mapping
+# => {:EMAIL_ADDRESS_1=>"user[at]example.com"}
+
+# Disable specific filters
+result = TopSecret::Text.scan("Ralph works in Boston", people_filter: nil)
+result.mapping
+# => {:LOCATION_1=>"Boston"}
+
+# Add custom filters
+ip_filter = TopSecret::Filters::Regex.new(
+  label: "IP_ADDRESS",
+  regex: /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/
+)
+result = TopSecret::Text.scan("Server IP is 192.168.1.1", custom_filters: [ip_filter])
+result.mapping
+# => {:IP_ADDRESS_1=>"192.168.1.1"}
+```
+
 ### Batch Processing
 
 When processing multiple messages, use `filter_all` to ensure consistent redaction labels across all messages:

--- a/lib/top_secret/text/batch_result.rb
+++ b/lib/top_secret/text/batch_result.rb
@@ -5,7 +5,7 @@ module TopSecret
     # Holds the result of a batch redaction operation on multiple messages.
     # Contains a global mapping that ensures consistent labeling across all messages
     # and a collection of individual input/output pairs.
-    class BatchResult
+    class BatchResult # TODO Rename to FilterBatchResult
       # @return [Hash] Global mapping of redaction labels to original values across all messages
       attr_reader :mapping
 

--- a/lib/top_secret/text/result.rb
+++ b/lib/top_secret/text/result.rb
@@ -3,7 +3,7 @@
 module TopSecret
   class Text
     # Holds the result of a redaction operation.
-    class Result
+    class Result # TODO: Rename to FilterResult
       # @return [String] The original unredacted input
       attr_reader :input
 

--- a/lib/top_secret/text/scan_result.rb
+++ b/lib/top_secret/text/scan_result.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module TopSecret
+  class Text
+    # Holds the result of a scan operation.
+    class ScanResult
+      # @return [Hash] Mapping of redacted labels to matched values
+      attr_reader :mapping
+
+      # @param mapping [Hash] Map of labels to matched values
+      def initialize(mapping)
+        @mapping = mapping
+      end
+
+      # @return [Boolean] Whether sensitive information was found
+      def sensitive?
+        mapping.any?
+      end
+    end
+  end
+end


### PR DESCRIPTION
Relates to this [discussion][1].

There are cases where callers want to know if text contains
sensitive information, rather than filtering that text.

This commit introduce `TopSecret::Text.scan` which returns the following
result:

```ruby
TopSecret::Text.scan("Ralph can be reached at ralph@thoughtbot.com")

TopSecret::Text::ScanResult
  @mapping={:EMAIL_1=>"ralph@thoughtbot.com", :PERSON_1=>"Ralph"}
>
```

This commit also refactors `TopSecret::Text#filter` to use the new
`#scan` method, resulting in a slight performance improvement. This is
because we check to see if the supplied input contains sensitive
information before filtering it.

[1]: https://github.com/thoughtbot/top_secret/discussions/50
