### PR TITLE
Improve regex for phone and add specs for other constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,8 @@ gem install top_secret
 >
 > Alternatively, you can disable NER filtering entirely by setting `model_path` to `nil` if you only need regex-based filters (credit cards, emails, phone numbers, SSNs). This improves performance and eliminates the model file dependency.
 
-By default, Top Secret assumes the file will live at the root of your project, but this can be configured.
-
-```ruby
-TopSecret.configure do |config|
-  config.model_path = "path/to/ner_model.dat"
-end
-```
+By default, Top Secret assumes the file will live at the root of your project.
+However, you can [override the model path](#overriding-the-model-path).
 
 ## Default Filters
 

--- a/lib/top_secret/constants.rb
+++ b/lib/top_secret/constants.rb
@@ -15,7 +15,7 @@ module TopSecret
   }x
 
   # @return [Regexp] Matches phone numbers with optional country code
-  PHONE_REGEX = /\b(?:\+\d{1,2}\s)?\(?\d{3}\)?[\s+.-]\d{3}[\s+.-]\d{4}\b/
+  PHONE_REGEX = /\b(?:\+\d{1,2}\s)?\(?\d{3}\)?[\s+.-]?\d{3}[\s+.-]?\d{4}\b/
 
   # @return [Regexp] Matches Social Security Numbers in common formats
   SSN_REGEX = /\b\d{3}[\s+-]\d{2}[\s+-]\d{4}\b/

--- a/spec/top_secret/constants_spec.rb
+++ b/spec/top_secret/constants_spec.rb
@@ -1,17 +1,66 @@
 # frozen_string_literal: true
 
-RSpec.describe "TopSecret::PHONE_REGEX" do
-  phone_numbers = [
-    "+1 415-555-1234",
-    "(415) 555-1234",
-    "415.555.1234",
-    "415 555 1234",
-    "415-555-1234"
-  ]
+RSpec.describe TopSecret do
+  describe "PHONE_REGEX" do
+    phone_numbers = [
+      "+1 415-555-1234",
+      "(415) 555-1234",
+      "415.555.1234",
+      "415 555 1234",
+      "415-555-1234",
+      "4155551234"
+    ]
 
-  phone_numbers.each do |phone_number|
-    it "matches #{phone_number}" do
-      expect(phone_number).to match(TopSecret::PHONE_REGEX)
+    phone_numbers.each do |phone_number|
+      it "matches #{phone_number}" do
+        expect(phone_number).to match(described_class::PHONE_REGEX)
+      end
+    end
+  end
+
+  describe "CREDIT_CARD_REGEX" do
+    credit_card_numbers = [
+      "4123 4567 8901 2345",
+      "5123-4567-8901-2346",
+      "6123456789012347",
+      "4123-4567-8901-2345",
+      "5123 4567 8901 2346"
+    ]
+
+    credit_card_numbers.each do |cc_number|
+      it "matches #{cc_number}" do
+        expect(cc_number).to match(described_class::CREDIT_CARD_REGEX)
+      end
+    end
+  end
+
+  describe "EMAIL_REGEX" do
+    email_addresses = [
+      "user@example.com",
+      "user.name+tag@example.co.uk",
+      "USER_123@example.io",
+      "user-name@example.travel",
+      "first.last@subdomain.example.org"
+    ]
+
+    email_addresses.each do |email|
+      it "matches #{email}" do
+        expect(email).to match(described_class::EMAIL_REGEX)
+      end
+    end
+  end
+
+  describe "SSN_REGEX" do
+    ssns = [
+      "123-45-6789",
+      "123 45 6789",
+      "123+45+6789"
+    ]
+
+    ssns.each do |ssn|
+      it "matches #{ssn}" do
+        expect(ssn).to match(described_class::SSN_REGEX)
+      end
     end
   end
 end

--- a/spec/top_secret/constants_spec.rb
+++ b/spec/top_secret/constants_spec.rb
@@ -53,8 +53,7 @@ RSpec.describe TopSecret do
   describe "SSN_REGEX" do
     ssns = [
       "123-45-6789",
-      "123 45 6789",
-      "123+45+6789"
+      "123 45 6789"
     ]
 
     ssns.each do |ssn|


### PR DESCRIPTION
- In addition to the existing phone regex constant spec, this PR adds specs for credit card, email and ssn.
- Change to phone regex. We should allow "5555555555" as a format. Further info here [designsystem.digital.gov documentation](https://designsystem.digital.gov/patterns/create-a-user-profile/phone-number/) _"Do not require users to enter hyphens or other characters"_ This follows a similar approach to the credit card regex currently in place.
- Removed duplication example of configuring the `model_path` in the `README`.

There could be a few minor improvements to the regex in SSN and Phone (for example we currently allow 123+123+1234), but that may be by design and I'll leave that for now.