### PR TITLE
Improve - move default model path to constants class

### DIFF
--- a/lib/top_secret.rb
+++ b/lib/top_secret.rb
@@ -45,7 +45,7 @@ require_relative "top_secret/filtered_text"
 module TopSecret
   include ActiveSupport::Configurable
 
-  config_accessor :model_path, default: "ner_model.dat"
+  config_accessor :model_path, default: MODEL_PATH
   config_accessor :min_confidence_score, default: MIN_CONFIDENCE_SCORE
 
   config_accessor :custom_filters, default: []

--- a/lib/top_secret/constants.rb
+++ b/lib/top_secret/constants.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 module TopSecret
+  # @return [String] The path to the NER model file
+  MODEL_PATH = "ner_model.dat"
+
   # @return [Regexp] Matches credit card numbers
   CREDIT_CARD_REGEX = /
     \b[3456]\d{15}\b |

--- a/lib/top_secret/text.rb
+++ b/lib/top_secret/text.rb
@@ -57,8 +57,10 @@ module TopSecret
     #   ip_filter = TopSecret::Filters::Regex.new(label: "IP", regex: /\d+\.\d+\.\d+\.\d+/)
     #   result = TopSecret::Text.filter_all(messages, custom_filters: [ip_filter])
     def self.filter_all(messages, custom_filters: [], **filters)
+      shared_model = TopSecret.model_path ? Mitie::NER.new(TopSecret.model_path) : nil
+
       individual_results = messages.map do |message|
-        new(message, filters:, custom_filters:).filter
+        new(message, filters:, custom_filters:, model: shared_model).filter
       end
 
       global_mapping = {}

--- a/lib/top_secret/text.rb
+++ b/lib/top_secret/text.rb
@@ -57,10 +57,8 @@ module TopSecret
     #   ip_filter = TopSecret::Filters::Regex.new(label: "IP", regex: /\d+\.\d+\.\d+\.\d+/)
     #   result = TopSecret::Text.filter_all(messages, custom_filters: [ip_filter])
     def self.filter_all(messages, custom_filters: [], **filters)
-      shared_model = TopSecret.model_path ? Mitie::NER.new(TopSecret.model_path) : nil
-
       individual_results = messages.map do |message|
-        new(message, filters:, custom_filters:, model: shared_model).filter
+        new(message, filters:, custom_filters:).filter
       end
 
       global_mapping = {}


### PR DESCRIPTION
Minor improvement, follows the same pattern as the other strings in `lib/top_secret.rb` and moves the `model_path` string to `TopSecret::Constants`