### PR TITLE
Support Rails 7.0+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 -   Added `TopSecret::Text.scan` method for detecting sensitive information without redacting text
 -   Added `TopSecret::Text::ScanResult` class to hold scan operation results with `mapping` and `sensitive?` methods
 -   Added support for disabling NER filtering by setting `model_path` to `nil` for improved performance and deployment flexibility
+-   Added support for Rails 7.0 and newer
 
 ### Changed
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     top_secret (0.2.0)
-      activesupport (~> 8.0, >= 8.0.2)
+      activesupport (>= 7.0.8, < 9)
       mitie (~> 0.3.2)
 
 GEM

--- a/lib/top_secret/version.rb
+++ b/lib/top_secret/version.rb
@@ -2,4 +2,6 @@
 
 module TopSecret
   VERSION = "0.2.0"
+  MINIMUM_RAILS_VERSION = ">= 7.0.8"
+  MAXIMUM_RAILS_VERSION = "< 9"
 end

--- a/top_secret.gemspec
+++ b/top_secret.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", "~> 8.0", ">= 8.0.2"
+  spec.add_dependency "activesupport", ">= 7.0.8", "< 9"
   spec.add_dependency "mitie", "~> 0.3.2"
 
   # For more information and examples about making a new gem, check out our

--- a/top_secret.gemspec
+++ b/top_secret.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", ">= 7.0.8", "< 9"
+  spec.add_dependency "activesupport", TopSecret::MINIMUM_RAILS_VERSION, TopSecret::MAXIMUM_RAILS_VERSION
   spec.add_dependency "mitie", "~> 0.3.2"
 
   # For more information and examples about making a new gem, check out our


### PR DESCRIPTION
We wanted to use top_secret on a project that is not yet on Rails 8, but the gemspec is pinning the requirements to be > 8.0. I haven't found a reason for this requirement, so this is just changing the gemspec requirement to allow Rails 7 setups.

---

I'm not aware of any reason for not doing this, let me know if there are any reasons! I'm happy to apply other changes to the code if this isn't sufficient for adding the support for Rails 7.