### PR TITLE
Introduce `TopSecret::Text::{BatchResult, Result}#{sensitive?, safe?}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,16 @@
 -   Added `TopSecret::Text.scan` method for detecting sensitive information without redacting text
 -   Added `TopSecret::Text::ScanResult` class to hold scan operation results with `mapping` and `sensitive?` methods
 -   Added `TopSecret::Text::GlobalMapping` class to manage consistent labeling across multiple filtering operations
--   Added factory methods to domain objects: `BatchResult.from_messages`, `Result.from_messages`, and `Item.from_results`
+-   Added factory methods to domain objects: `BatchResult.from_messages`, `Result.from_messages`, and `Result.with_global_labels`
 -   Added support for disabling NER filtering by setting `model_path` to `nil` for improved performance and deployment flexibility
 -   Added support for Rails 7.0 and newer
+-   Added `#safe?` predicate method as the logical opposite of `#sensitive?` for `BatchResult`, `Result` and `ScanResult` classes
 
 ### Changed
 
+-   **BREAKING:** `TopSecret::Text.filter_all` now returns `TopSecret::Text::Result` objects instead of `TopSecret::Text::BatchResult::Item` objects for individual items
+-   Each item in `BatchResult#items` now includes an individual `mapping` attribute containing only the sensitive information found in that specific message
+-   `TopSecret::Text.filter_all` now only processes sensitive results when building global mappings, improving efficiency
 -   Refactored `TopSecret::Text.filter_all` to use domain objects with better separation of concerns and testability
 -   Improved performance by implementing lazy loading of MITIE model and document processing
 -   NER filtering now gracefully falls back when MITIE model is unavailable, continuing with regex-based filters only

--- a/README.md
+++ b/README.md
@@ -163,6 +163,18 @@ result.mapping
 # => {:EMAIL_1=>"ralph@thoughtbot.com", :PERSON_1=>"Ralph"}
 ```
 
+Check if sensitive information was found
+
+```ruby
+result.sensitive?
+
+# => true
+
+result.safe?
+
+# => false
+```
+
 ### Scanning for Sensitive Information
 
 Use `TopSecret::Text.scan` to detect sensitive information without redacting the text. This is useful when you only need to check if sensitive data exists or get a mapping of what was found:
@@ -185,6 +197,10 @@ Check if sensitive information was found
 result.sensitive?
 
 # => true
+
+result.safe?
+
+# => false
 ```
 
 View the mapping of found sensitive information
@@ -242,9 +258,9 @@ This will return
 <TopSecret::Text::BatchResult
   @mapping={:EMAIL_1=>"ralph@thoughtbot.com", :EMAIL_2=>"ruby@thoughtbot.com"},
   @items=[
-    <TopSecret::Text::BatchResult::Item @input="Contact ralph@thoughtbot.com for details", @output="Contact [EMAIL_1] for details">,
-    <TopSecret::Text::BatchResult::Item @input="Email ralph@thoughtbot.com again if needed", @output="Email [EMAIL_1] again if needed">,
-    <TopSecret::Text::BatchResult::Item @input="Also CC ruby@thoughtbot.com on the thread", @output="Also CC [EMAIL_2] on the thread">
+    <TopSecret::Text::Result @input="Contact ralph@thoughtbot.com for details", @output="Contact [EMAIL_1] for details", @mapping={:EMAIL_1=>"ralph@thoughtbot.com"}>,
+    <TopSecret::Text::Result @input="Email ralph@thoughtbot.com again if needed", @output="Email [EMAIL_1] again if needed", @mapping={:EMAIL_1=>"ralph@thoughtbot.com"}>,
+    <TopSecret::Text::Result @input="Also CC ruby@thoughtbot.com on the thread", @output="Also CC [EMAIL_2] on the thread", @mapping={:EMAIL_2=>"ruby@thoughtbot.com"}>
   ]
 >
 ```
@@ -265,9 +281,20 @@ result.items[0].input
 
 result.items[0].output
 # => "Contact [EMAIL_1] for details"
+
+result.items[0].mapping
+# => {:EMAIL_1=>"ralph@thoughtbot.com"}
+
+result.items[0].sensitive?
+# => true
+
+result.items[0].safe?
+# => false
 ```
 
 The key benefit is that identical values receive the same labels across all messages - notice how `ralph@thoughtbot.com` becomes `[EMAIL_1]` in both the first and second messages.
+
+Each item also maintains its own mapping containing only the sensitive information found in that specific message, while the batch result provides a global mapping of all sensitive information across all messages.
 
 ### Restoring Filtered Text
 

--- a/lib/top_secret.rb
+++ b/lib/top_secret.rb
@@ -8,6 +8,7 @@ require "mitie"
 # modules
 require_relative "top_secret/version"
 require_relative "top_secret/constants"
+require_relative "top_secret/mapping"
 require_relative "top_secret/filters/ner"
 require_relative "top_secret/filters/regex"
 require_relative "top_secret/error"

--- a/lib/top_secret/mapping.rb
+++ b/lib/top_secret/mapping.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module TopSecret
+  module Mapping
+    # @return [Boolean] Whether sensitive information was found
+    def sensitive?
+      mapping.any?
+    end
+
+    # @return [Boolean] Whether sensitive information was not found
+    def safe?
+      !sensitive?
+    end
+  end
+end

--- a/lib/top_secret/text.rb
+++ b/lib/top_secret/text.rb
@@ -45,7 +45,7 @@ module TopSecret
     # @param messages [Array<String>] Array of text messages to filter
     # @param custom_filters [Array] Additional custom filters to apply
     # @param filters [Hash] Optional filters to override defaults (only valid filter keys accepted)
-    # @return [BatchResult] Contains global mapping and array of input/output pairs
+    # @return [BatchResult] Contains global mapping and array of Result objects with individual mappings
     # @raise [ArgumentError] If invalid filter keys are provided
     #
     # @example Basic usage
@@ -53,6 +53,7 @@ module TopSecret
     #   result = TopSecret::Text.filter_all(messages)
     #   result.items[0].output # => "Contact [EMAIL_1]"
     #   result.items[1].output # => "Email [EMAIL_1] again"
+    #   result.items[0].mapping # => { EMAIL_1: "john@test.com" }
     #   result.mapping # => { EMAIL_1: "john@test.com" }
     #
     # @example With custom filters

--- a/lib/top_secret/text/batch_result.rb
+++ b/lib/top_secret/text/batch_result.rb
@@ -6,6 +6,8 @@ module TopSecret
     # Contains a global mapping that ensures consistent labeling across all messages
     # and a collection of individual input/output pairs.
     class BatchResult # TODO Rename to FilterBatchResult
+      include Mapping
+
       # @return [Hash] Global mapping of redaction labels to original values across all messages
       attr_reader :mapping
 
@@ -26,47 +28,14 @@ module TopSecret
       # @param messages [Array<String>] Array of text messages to filter
       # @param custom_filters [Array] Additional custom filters to apply
       # @param filters [Hash] Optional filters to override defaults (only valid filter keys accepted)
-      # @return [BatchResult] Contains global mapping and array of Item objects with individual mappings
+      # @return [BatchResult] Contains global mapping and array of Result objects with individual mappings
       # @raise [ArgumentError] If invalid filter keys are provided
       def self.from_messages(messages, custom_filters: [], **filters)
         individual_results = TopSecret::Text::Result.from_messages(messages, custom_filters:, **filters)
         mapping = TopSecret::Text::GlobalMapping.from_results(individual_results)
-        items = Text::BatchResult::Item.from_results(individual_results, mapping)
+        items = TopSecret::Text::Result.with_global_labels(individual_results, mapping)
 
         Text::BatchResult.new(mapping:, items:)
-      end
-
-      # Represents a single message within a batch redaction operation.
-      # Contains only the input and output text, without individual mappings.
-      # The mapping is maintained at the BatchResult level for global consistency.
-      class Item
-        # @return [String] The original unredacted input
-        attr_reader :input
-
-        # @return [String] The redacted output
-        attr_reader :output
-
-        # Creates a new Item instance
-        #
-        # @param input [String] The original text
-        # @param output [String] The redacted text
-        def initialize(input, output)
-          @input = input
-          @output = output
-        end
-
-        # Creates Item objects from individual results using global mapping for consistent labels
-        #
-        # @param individual_results [Array<Result>] Array of individual filter results
-        # @param global_mapping [Hash] Global mapping from filter labels to original values
-        # @return [Array<Item>] Array of Item objects with globally consistent redaction
-        def self.from_results(individual_results, global_mapping)
-          individual_results.map do |result|
-            output = result.input.dup
-            global_mapping.each { |filter, value| output.gsub!(value, "[#{filter}]") }
-            Text::BatchResult::Item.new(result.input, output)
-          end
-        end
       end
     end
   end

--- a/lib/top_secret/text/global_mapping.rb
+++ b/lib/top_secret/text/global_mapping.rb
@@ -24,7 +24,7 @@ module TopSecret
       # @param individual_results [Array<Result>] Array of individual filter results
       # @return [Hash] Inverted mapping from filter labels to original values
       def build_from_results(individual_results)
-        individual_results.each { |result| process_result(result) }
+        individual_results.each { |result| process_result(result) if result.sensitive? }
 
         mapping.invert
       end

--- a/lib/top_secret/text/scan_result.rb
+++ b/lib/top_secret/text/scan_result.rb
@@ -4,17 +4,14 @@ module TopSecret
   class Text
     # Holds the result of a scan operation.
     class ScanResult
+      include Mapping
+
       # @return [Hash] Mapping of redacted labels to matched values
       attr_reader :mapping
 
       # @param mapping [Hash] Map of labels to matched values
       def initialize(mapping)
         @mapping = mapping
-      end
-
-      # @return [Boolean] Whether sensitive information was found
-      def sensitive?
-        mapping.any?
       end
     end
   end

--- a/spec/top_secret/batch_result_spec.rb
+++ b/spec/top_secret/batch_result_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe TopSecret::Text::BatchResult do
+  subject { described_class.new(mapping:, items: []) }
+
+  describe "#safe?" do
+    context "when #mapping is empty" do
+      let(:mapping) { {} }
+
+      it "returns true" do
+        expect(subject.safe?).to be true
+      end
+    end
+
+    context "when #mapping has values" do
+      let(:mapping) { {EMAIL_1: "ralph@example.com"} }
+
+      it "returns false" do
+        expect(subject.safe?).to be false
+      end
+    end
+  end
+
+  describe "#sensitive?" do
+    context "when #mapping is empty" do
+      let(:mapping) { {} }
+
+      it "returns false" do
+        expect(subject.sensitive?).to be false
+      end
+    end
+
+    context "when #mapping has values" do
+      let(:mapping) { {EMAIL_1: "ralph@example.com"} }
+
+      it "returns true" do
+        expect(subject.sensitive?).to be true
+      end
+    end
+  end
+end

--- a/spec/top_secret/result_spec.rb
+++ b/spec/top_secret/result_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe TopSecret::Text::Result do
+  subject { described_class.new("input", "output", mapping) }
+
+  describe "#safe?" do
+    context "when #mapping is empty" do
+      let(:mapping) { {} }
+
+      it "returns true" do
+        expect(subject.safe?).to be true
+      end
+    end
+
+    context "when #mapping has values" do
+      let(:mapping) { {EMAIL_1: "ralph@example.com"} }
+
+      it "returns false" do
+        expect(subject.safe?).to be false
+      end
+    end
+  end
+
+  describe "#sensitive?" do
+    context "when #mapping is empty" do
+      let(:mapping) { {} }
+
+      it "returns false" do
+        expect(subject.sensitive?).to be false
+      end
+    end
+
+    context "when #mapping has values" do
+      let(:mapping) { {EMAIL_1: "ralph@example.com"} }
+
+      it "returns true" do
+        expect(subject.sensitive?).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
In #70 we introduced `TopSecret::Text#scan`, which returns an object
that responds to `sensitive?`.

This commit updates both `TopSecret::Text::BatchResult` and
`TopSecret::Text::Result` to do the same. In order do do this, we
introduce a `Mapping` module to be shared across all three classes.
We also introduce `#safe?` to compliment `#sensitive?`.

This meant that `TopSecret::Text::BatchResult::Item` had the same
interface as `TopSecret::Text::Result`. Because of this, we remove that
class altogether, and replace it with `TopSecret::Text::Result`.
