### PR TITLE
Fix ActiveSupport dependency declaration

### DIFF
--- a/top_secret.gemspec
+++ b/top_secret.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", TopSecret::MINIMUM_RAILS_VERSION, TopSecret::MAXIMUM_RAILS_VERSION
+  spec.add_dependency "activesupport", TopSecret::MAXIMUM_RAILS_VERSION, TopSecret::MINIMUM_RAILS_VERSION
   spec.add_dependency "mitie", "~> 0.3.2"
 
   # For more information and examples about making a new gem, check out our


### PR DESCRIPTION
`add_dependency` accepts an upper bound then a lower bound when limiting versioning; thus, it effectively sets the lower bound to `< 9` rather than `>= 7.0.8`.

Ref:  https://guides.rubygems.org/specification-reference/#add_dependency