### PR TITLE
Refactor `TopSecret::Text.filter_all`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@
 
 -   Added `TopSecret::Text.scan` method for detecting sensitive information without redacting text
 -   Added `TopSecret::Text::ScanResult` class to hold scan operation results with `mapping` and `sensitive?` methods
+-   Added `TopSecret::Text::GlobalMapping` class to manage consistent labeling across multiple filtering operations
+-   Added factory methods to domain objects: `BatchResult.from_messages`, `Result.from_messages`, and `Item.from_results`
 -   Added support for disabling NER filtering by setting `model_path` to `nil` for improved performance and deployment flexibility
 -   Added support for Rails 7.0 and newer
 
 ### Changed
 
+-   Refactored `TopSecret::Text.filter_all` to use domain objects with better separation of concerns and testability
 -   Improved performance by implementing lazy loading of MITIE model and document processing
 -   NER filtering now gracefully falls back when MITIE model is unavailable, continuing with regex-based filters only
 

--- a/lib/top_secret/text/batch_result.rb
+++ b/lib/top_secret/text/batch_result.rb
@@ -21,6 +21,21 @@ module TopSecret
         @items = items
       end
 
+      # Creates a BatchResult from multiple messages with consistent global labeling
+      #
+      # @param messages [Array<String>] Array of text messages to filter
+      # @param custom_filters [Array] Additional custom filters to apply
+      # @param filters [Hash] Optional filters to override defaults (only valid filter keys accepted)
+      # @return [BatchResult] Contains global mapping and array of Item objects with individual mappings
+      # @raise [ArgumentError] If invalid filter keys are provided
+      def self.from_messages(messages, custom_filters: [], **filters)
+        individual_results = TopSecret::Text::Result.from_messages(messages, custom_filters:, **filters)
+        mapping = TopSecret::Text::GlobalMapping.from_results(individual_results)
+        items = Text::BatchResult::Item.from_results(individual_results, mapping)
+
+        Text::BatchResult.new(mapping:, items:)
+      end
+
       # Represents a single message within a batch redaction operation.
       # Contains only the input and output text, without individual mappings.
       # The mapping is maintained at the BatchResult level for global consistency.
@@ -38,6 +53,19 @@ module TopSecret
         def initialize(input, output)
           @input = input
           @output = output
+        end
+
+        # Creates Item objects from individual results using global mapping for consistent labels
+        #
+        # @param individual_results [Array<Result>] Array of individual filter results
+        # @param global_mapping [Hash] Global mapping from filter labels to original values
+        # @return [Array<Item>] Array of Item objects with globally consistent redaction
+        def self.from_results(individual_results, global_mapping)
+          individual_results.map do |result|
+            output = result.input.dup
+            global_mapping.each { |filter, value| output.gsub!(value, "[#{filter}]") }
+            Text::BatchResult::Item.new(result.input, output)
+          end
         end
       end
     end

--- a/lib/top_secret/text/global_mapping.rb
+++ b/lib/top_secret/text/global_mapping.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module TopSecret
+  class Text
+    # Manages consistent labeling across multiple filtering operations by ensuring
+    # identical sensitive values receive the same redaction labels globally.
+    class GlobalMapping
+      # Creates a global mapping from individual filter results
+      #
+      # @param individual_results [Array<Result>] Array of individual filter results
+      # @return [Hash] Inverted mapping from filter labels to original values
+      def self.from_results(individual_results)
+        new.build_from_results(individual_results)
+      end
+
+      # Creates a new GlobalMapping instance
+      def initialize
+        @mapping = {}
+        @label_counters = {}
+      end
+
+      # Builds the global mapping by processing all individual results
+      #
+      # @param individual_results [Array<Result>] Array of individual filter results
+      # @return [Hash] Inverted mapping from filter labels to original values
+      def build_from_results(individual_results)
+        individual_results.each { |result| process_result(result) }
+
+        mapping.invert
+      end
+
+      private
+
+      attr_reader :mapping
+      attr_reader :label_counters
+
+      # Processes a single result, adding new values to the global mapping
+      #
+      # @param result [Result] Individual filter result to process
+      def process_result(result)
+        result.mapping.each do |individual_key, value|
+          next if mapping.key?(value)
+
+          mapping[value] = generate_global_key(individual_key)
+        end
+      end
+
+      # Generates a consistent global key for a given individual key
+      #
+      # @param individual_key [Symbol] The individual key from a filter result
+      # @return [Symbol] The global key with consistent numbering
+      def generate_global_key(individual_key)
+        # TODO: This assumes labels are formatted consistently.
+        # We need to account for the following for the case where a label could begin with an "_"
+        label_type = individual_key.to_s.rpartition("_").first
+
+        label_counters[label_type] ||= 0
+        label_counters[label_type] += 1
+        :"#{label_type}_#{label_counters[label_type]}"
+      end
+    end
+  end
+end

--- a/lib/top_secret/text/result.rb
+++ b/lib/top_secret/text/result.rb
@@ -21,6 +21,21 @@ module TopSecret
         @output = output
         @mapping = mapping
       end
+
+      # Filters multiple messages individually using a shared model for performance
+      #
+      # @param messages [Array<String>] Array of text messages to filter
+      # @param custom_filters [Array] Additional custom filters to apply
+      # @param filters [Hash] Optional filters to override defaults (only valid filter keys accepted)
+      # @return [Array<Result>] Array of individual Result objects for each message
+      # @raise [ArgumentError] If invalid filter keys are provided
+      def self.from_messages(messages, custom_filters: [], **filters)
+        shared_model = TopSecret.model_path ? Mitie::NER.new(TopSecret.model_path) : nil
+
+        messages.map do |message|
+          TopSecret::Text.new(message, filters:, custom_filters:, model: shared_model).filter
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
In an effort to support #77, we extract the procedural code from
`TopSecret::Text.filter_all` into several domain objects.

These changes really only affect the private API, but do allow for
callers to more easily build result objects if needed.
