### PR TITLE
Prepare for `v0.3.0` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [0.3.0] - 2025-09-19
+
 ### Added
 
 -   Added `TopSecret::Text.scan` method for detecting sensitive information without redacting text

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    top_secret (0.2.0)
+    top_secret (0.3.0)
       activesupport (>= 7.0.8, < 9)
       mitie (~> 0.3.2)
 

--- a/lib/top_secret/version.rb
+++ b/lib/top_secret/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module TopSecret
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
   MINIMUM_RAILS_VERSION = ">= 7.0.8"
   MAXIMUM_RAILS_VERSION = "< 9"
 end


### PR DESCRIPTION
Now that we support Rails 7+ (#74), it feels like the right time to cut
a new release, rather than delay it to add more features.
