### PR TITLE
Optimize `Mitie::NER` initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Added
+
+-   Added `TopSecret.shared_model` configuration option for caching the MITIE model instance to avoid expensive reinitialization
+
 ## [0.3.0] - 2025-09-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -568,6 +568,27 @@ TopSecret.configure do |config|
 end
 ```
 
+### Caching the MITIE model
+
+By default, each `TopSecret::Text` instance creates a new MITIE model, which can be slow. To improve performance, you can cache a single shared model instance:
+
+```ruby
+TopSecret.configure do |config|
+  config.shared_model = Mitie::NER.new(config.model_path)
+end
+```
+
+This is particularly useful in Rails applications. Add this to an initializer to load the model once at boot:
+
+```ruby
+# config/initializers/top_secret.rb
+Rails.application.config.after_initialize do
+  TopSecret.shared_model = Mitie::NER.new(config.model_path) if config.model_path
+end
+```
+
+All `TopSecret::Text` instances will reuse this cached model, significantly improving performance.
+
 ### Disabling NER filtering
 
 For improved performance or when the MITIE model file cannot be deployed, you can disable NER-based filtering entirely. This will disable people and location detection but retain all regex-based filters (credit cards, emails, phone numbers, SSNs):

--- a/lib/top_secret.rb
+++ b/lib/top_secret.rb
@@ -48,6 +48,7 @@ module TopSecret
 
   config_accessor :model_path, default: MODEL_PATH
   config_accessor :min_confidence_score, default: MIN_CONFIDENCE_SCORE
+  config_accessor :shared_model
 
   config_accessor :custom_filters, default: []
 

--- a/lib/top_secret/text.rb
+++ b/lib/top_secret/text.rb
@@ -225,9 +225,12 @@ module TopSecret
 
     # Creates the default model based on configuration.
     # Returns a MITIE NER model if a model path is configured, otherwise returns a null model.
+    # If a shared_model is configured, it will be used instead of creating a new instance.
     #
     # @return [Mitie::NER, NullModel] The model instance to use for NER processing
     def default_model
+      return TopSecret.shared_model if TopSecret.shared_model
+
       if TopSecret.model_path
         Mitie::NER.new(TopSecret.model_path)
       else


### PR DESCRIPTION
Initializing `Mitie::NER` is expensive. By pushing the initialization
into the configuration, we aim to initialize once a boot, assuming a
Rails application.
