### PR TITLE
Cache `Mitie::NER` initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Added
+
+-   Added automatic caching of MITIE NER model to improve performance by avoiding expensive reinitialization
+-   Added `TopSecret::Text.clear_model_cache!` method to clear the cached model when needed
+
 ## [0.3.0] - 2025-09-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -568,6 +568,16 @@ TopSecret.configure do |config|
 end
 ```
 
+### Model caching
+
+The MITIE NER model is automatically cached after the first initialization to avoid expensive reloading. All `TopSecret::Text` instances share the same cached model, significantly improving performance.
+
+If you need to clear the cache (e.g., after changing the model path), use:
+
+```ruby
+TopSecret::Text.clear_model_cache!
+```
+
 ### Disabling NER filtering
 
 For improved performance or when the MITIE model file cannot be deployed, you can disable NER-based filtering entirely. This will disable people and location detection but retain all regex-based filters (credit cards, emails, phone numbers, SSNs):

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,11 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  # Clear the cached model before each test to ensure test isolation
+  config.before(:each) do
+    TopSecret::Text.clear_model_cache!
+  end
 end
 
 def build_entity(text:, tag:, score: TopSecret.min_confidence_score)


### PR DESCRIPTION
Initializing `Mitie::NER` is expensive, so we cache it. In an effort to make it
thread-safe, we use a Mutex.

Although #85 is a simpler approach, it's not practical because if you're using
[Trove](https://github.com/ankane/trove), and [pulling during asset
pre-compilation](https://github.com/ankane/trove), the file will not exist
during initialization.

Claude Code helped drive this out, but it was tested in a production-like
environment and worked. The first request was slow, but subsequent requests were
cached.
