### PR TITLE
Prepare for `v0.4.0` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [0.4.0] - 2025-10-31
+
 ### Added
 
 -   Added automatic caching of MITIE NER model to improve performance by avoiding expensive reinitialization

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    top_secret (0.3.0)
+    top_secret (0.4.0)
       activesupport (>= 7.0.8, < 9)
       mitie (~> 0.3.2)
 

--- a/lib/top_secret/version.rb
+++ b/lib/top_secret/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module TopSecret
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
   MINIMUM_RAILS_VERSION = ">= 7.0.8"
   MAXIMUM_RAILS_VERSION = "< 9"
 end


### PR DESCRIPTION
Now that we have a performance improvement, it feels like a good
opportunity to release a new version.
