### PR TITLE
Breaking change: Validate labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 ## [Unreleased]
 
+### Changed
+
+-   **BREAKING:** Added strict label validation for custom filters. Labels must now start and end with letters and contain only alphabetic characters and single underscores (no consecutive underscores, digits, or special characters). Previously malformed labels will now raise `Error::MalformedLabel`.
+
+### Migration Guide
+
+If you have custom filters with malformed labels, update them to meet the new requirements:
+
+```ruby
+# Before (invalid)
+TopSecret::Filters::Regex.new(label: "EMAIL_ADDRESS_1", regex: /.../)
+TopSecret::Filters::Regex.new(label: "_EMAIL", regex: /.../)
+TopSecret::Filters::Regex.new(label: "EMAIL1", regex: /.../)
+
+# After (valid)
+TopSecret::Filters::Regex.new(label: "EMAIL_ADDRESS", regex: /.../)
+TopSecret::Filters::Regex.new(label: "EMAIL", regex: /.../)
+TopSecret::Filters::Regex.new(label: "EMAIL", regex: /.../)
+```
+
+Note: The `_N` suffix is appended automatically by the system during mapping.
+
 ## [0.4.0] - 2025-10-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -453,6 +453,20 @@ TopSecret::Text.filter("some text", invalid_filter: some_filter)
 
 ### Custom Filters
 
+> [!IMPORTANT]
+> Custom filter labels must follow these rules:
+>
+> -   Start with a letter (a-z, A-Z)
+> -   End with a letter (a-z, A-Z)
+> -   Contain only letters and single underscores (no consecutive underscores)
+> -   Cannot contain digits or special characters
+>
+> Valid examples: `EMAIL`, `IP_ADDRESS`, `CREDIT_CARD`
+>
+> Invalid examples: `_EMAIL` (starts with underscore), `EMAIL_` (ends with underscore), `EMAIL1` (ends with digit), `EMAIL__ADDRESS` (consecutive underscores)
+>
+> The system automatically appends `_N` where N is the sequence number (e.g., `EMAIL_ADDRESS` becomes `EMAIL_ADDRESS_1`, `EMAIL_ADDRESS_2`, etc.)
+
 #### Adding new [Regex filters][]
 
 ```ruby

--- a/lib/top_secret/error.rb
+++ b/lib/top_secret/error.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 module TopSecret
-  class Error < StandardError; end
+  class Error < StandardError
+    class MalformedLabel < StandardError; end
+  end
 end

--- a/lib/top_secret/text/global_mapping.rb
+++ b/lib/top_secret/text/global_mapping.rb
@@ -50,8 +50,6 @@ module TopSecret
       # @param individual_key [Symbol] The individual key from a filter result
       # @return [Symbol] The global key with consistent numbering
       def generate_global_key(individual_key)
-        # TODO: This assumes labels are formatted consistently.
-        # We need to account for the following for the case where a label could begin with an "_"
         label_type = individual_key.to_s.rpartition("_").first
 
         label_counters[label_type] ||= 0

--- a/spec/top_secret/text_spec.rb
+++ b/spec/top_secret/text_spec.rb
@@ -473,6 +473,46 @@ RSpec.describe TopSecret::Text do
         expect(result.output).to eq("Boston")
       end
     end
+
+    context "when a malformed label is passed" do
+      %w[
+        _EMAIL_ADDRESS
+        EMAIL_ADDRESS_
+        1EMAIL_ADDRESS
+        EMAIL_ADDRESS1
+        1_EMAIL_ADDRESS
+        EMAIL_ADDRESS_1
+        *EMAIL_ADDRESS
+        EMAIL_ADDRESS*
+        EMAIL__ADDRESS
+        EMAIL*ADDRESS
+        EMAIL1ADDRESS
+      ].each do |invalid_label|
+        it "raises when label is '#{invalid_label}'" do
+          expect {
+            TopSecret::Text.filter("", email_filter: TopSecret::Filters::Regex.new(
+              label: invalid_label,
+              regex: /user\[at\]example\.com/
+            ))
+          }.to raise_error(TopSecret::Error::MalformedLabel, "Unsupported label. Labels must contain only letters and underscores: '#{invalid_label}'")
+        end
+      end
+
+      [
+        "",
+        " ",
+        nil
+      ].each do |blank_label|
+        it "raises raises when label is '#{blank_label}'" do
+          expect {
+            TopSecret::Text.filter("", email_filter: TopSecret::Filters::Regex.new(
+              label: blank_label,
+              regex: /user\[at\]example\.com/
+            ))
+          }.to raise_error(TopSecret::Error::MalformedLabel, "You must provide a label.")
+        end
+      end
+    end
   end
 
   describe ".filter_all" do


### PR DESCRIPTION
In an effort to support [dynamically generating predicate methods][1],
we first need to ensure labels are formatted consistently. This is
because (for now) I plan to build those methods from the label.

Labels must meet the following criteria:

-   Start with a letter (a-z, A-Z)
-   End with a letter (a-z, A-Z)
-   Contain only letters and single underscores (no consecutive underscores)
-   Not be blank or nil

[1]: https://github.com/thoughtbot/top_secret/discussions/71
