### PR TITLE
Introduce category methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## [Unreleased]
 
+### Added
+
+-   Added category methods to `Result` for querying specific types of sensitive information (e.g., `emails`, `emails?`, `email_mapping`)
+-   Category methods are automatically generated for all default filter types and custom labels
+-   Category methods always return empty arrays/hashes when no data of that type is found, ensuring they're safe to call without checking
+-   Custom labels are matched exactly — `EMAIL_ADDRESS` methods are distinct from default `EMAIL` methods
+-   Added `categories` method to `Result` for listing category types that have matches in the mapping
+
 ### Changed
 
 -   **BREAKING:** Added strict label validation for custom filters. Labels must now start and end with letters and contain only alphabetic characters and single underscores (no consecutive underscores, digits, or special characters). Previously malformed labels will now raise `Error::MalformedLabel`.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,104 @@ result.safe?
 # => false
 ```
 
+### Category Methods
+
+Query the result for specific types of sensitive information using category methods:
+
+```ruby
+result = TopSecret::Text.filter("Ralph can be reached at ralph@example.com or 555-1234")
+
+# Check if emails were found
+result.emails?
+# => true
+
+# Get all emails
+result.emails
+# => ["ralph@example.com"]
+
+# Get email mapping
+result.email_mapping
+# => {:EMAIL_1=>"ralph@example.com"}
+
+# Similarly for other types
+result.people?         # => true
+result.people          # => ["Ralph"]
+result.person_mapping  # => {:PERSON_1=>"Ralph"}
+
+result.phone_numbers?         # => true
+result.phone_numbers          # => ["555-1234"]
+result.phone_number_mapping   # => {:PHONE_NUMBER_1=>"555-1234"}
+```
+
+Available category methods for all default filters:
+
+- `emails`, `emails?`, `email_mapping`
+- `credit_cards`, `credit_cards?`, `credit_card_mapping`
+- `phone_numbers`, `phone_numbers?`, `phone_number_mapping`
+- `ssns`, `ssns?`, `ssn_mapping`
+- `people`, `people?`, `person_mapping`
+- `locations`, `locations?`, `location_mapping`
+
+Use `categories` to see which types were found in the result:
+
+```ruby
+result = TopSecret::Text.filter("Ralph can be reached at ralph@example.com")
+
+result.categories
+# => [:email, :person]
+```
+
+These methods are always available and return empty arrays/hashes when no sensitive information of that type is found:
+
+```ruby
+result = TopSecret::Text.filter("No sensitive data here")
+
+result.emails?         # => false
+result.emails          # => []
+result.email_mapping   # => {}
+```
+
+When using custom labels, methods are generated based on the label name. Each label is matched exactly — a custom label like `EMAIL_ADDRESS` produces its own set of methods, separate from the default `EMAIL` methods:
+
+```ruby
+result = TopSecret::Text.filter(
+  "user[at]example.com",
+  email_filter: TopSecret::Filters::Regex.new(
+    label: "EMAIL_ADDRESS",
+    regex: /\w+\[at\]\w+\.\w+/
+  )
+)
+
+# Methods are derived from the custom label (EMAIL_ADDRESS)
+result.email_addresses          # => ["user[at]example.com"]
+result.email_addresses?         # => true
+result.email_address_mapping    # => {:EMAIL_ADDRESS_1=>"user[at]example.com"}
+
+# Default email methods only match the default EMAIL label, not EMAIL_ADDRESS
+result.emails                   # => []
+result.email_mapping            # => {}
+
+# If the custom label matches the default, both refer to the same data
+result = TopSecret::Text.filter(
+  "user[at]example.com",
+  email_filter: TopSecret::Filters::Regex.new(
+    label: "EMAIL",
+    regex: /\w+\[at\]\w+\.\w+/
+  )
+)
+
+result.emails                   # => ["user[at]example.com"]
+result.email_mapping            # => {:EMAIL_1=>"user[at]example.com"}
+```
+
+When a custom label ends in `_MAPPING` (e.g., `NETWORK_MAPPING`), the mapping method appends `_mapping` to the pluralized form to keep the naming pattern consistent:
+
+```ruby
+result.network_mappings          # => ["10.0.1.0/24 -> 192.168.1.0/24"]
+result.network_mappings?         # => true
+result.network_mappings_mapping  # => {:NETWORK_MAPPING_1=>"10.0.1.0/24 -> 192.168.1.0/24"}
+```
+
 ### Scanning for Sensitive Information
 
 Use `TopSecret::Text.scan` to detect sensitive information without redacting the text. This is useful when you only need to check if sensitive data exists or get a mapping of what was found:

--- a/lib/top_secret.rb
+++ b/lib/top_secret.rb
@@ -7,6 +7,7 @@ require "mitie"
 # modules
 require_relative "top_secret/version"
 require_relative "top_secret/constants"
+require_relative "top_secret/category"
 require_relative "top_secret/mapping"
 require_relative "top_secret/filters/ner"
 require_relative "top_secret/filters/regex"

--- a/lib/top_secret/category.rb
+++ b/lib/top_secret/category.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/string/inflections"
+
+module TopSecret
+  # Represents a category of sensitive information (e.g., email, person, credit_card).
+  #
+  # Each category derives a set of method names from its type and can resolve
+  # those methods against a mapping to return filtered results.
+  #
+  # @example
+  #   category = TopSecret::Category.new(:email)
+  #   category.plural          # => :emails
+  #   category.predicate       # => :emails?
+  #   category.mapping_method  # => :email_mapping
+  class Category
+    MAPPING_SUFFIX = "_mapping"
+
+    # @return [String] the category type (e.g., "email", "credit_card")
+    attr_reader :type
+
+    # Builds categories from a mapping's keys and a list of filters.
+    #
+    # @param mapping [Hash] the label-to-value mapping (e.g., +{EMAIL_1: "ralph@example.com"}+)
+    # @param filters [Array<TopSecret::Filters::Regex, TopSecret::Filters::NER>] active filters
+    # @return [Array<Category>] unique categories derived from the mapping and filters
+    def self.from(mapping:, filters:)
+      types_from_mapping = mapping.keys.map do |key|
+        key.to_s.rpartition(TopSecret::LABEL_DELIMITER).first.downcase
+      end
+
+      types_from_filters = filters.map { |filter| filter.label.downcase }
+
+      (types_from_mapping + types_from_filters).uniq.map { |type| new(type) }
+    end
+
+    # @param type [String, Symbol] the category type
+    def initialize(type)
+      @type = type.to_s
+    end
+
+    # Whether this category recognizes the given method name.
+    #
+    # @param method_name [Symbol] the method name to check
+    # @return [Boolean]
+    def respond_to_method?(method_name)
+      method_names.include?(method_name)
+    end
+
+    # @return [Symbol] the pluralized type (e.g., +:emails+)
+    def plural
+      @type.pluralize.to_sym
+    end
+
+    # @return [Symbol] the predicate method name (e.g., +:emails?+)
+    def predicate
+      :"#{plural}?"
+    end
+
+    # @return [Symbol] the mapping method name (e.g., +:email_mapping+)
+    def mapping_method
+      if @type.end_with?(MAPPING_SUFFIX)
+        :"#{@type.pluralize}#{MAPPING_SUFFIX}"
+      else
+        :"#{@type}#{MAPPING_SUFFIX}"
+      end
+    end
+
+    # @return [Symbol] the mapping predicate method name (e.g., +:email_mapping?+)
+    def mapping_predicate
+      :"#{mapping_method}?"
+    end
+
+    # Whether the mapping contains any keys belonging to this category.
+    #
+    # @param mapping [Hash] the label-to-value mapping
+    # @return [Boolean]
+    def matches?(mapping)
+      mapping.any? { |key, _| key.to_s.match?(key_pattern) }
+    end
+
+    # Resolves a method name against the mapping, returning the appropriate result.
+    #
+    # @param method_name [Symbol] one of {#plural}, {#predicate}, {#mapping_method}, or {#mapping_predicate}
+    # @param mapping [Hash] the label-to-value mapping
+    # @return [Hash, Array, Boolean] filtered mapping, values, or boolean depending on the method
+    # @raise [ArgumentError] if the method name is not recognized
+    def resolve(method_name, mapping)
+      filtered = filter_mapping(mapping)
+
+      case method_name
+      when mapping_method then filtered
+      when plural then filtered.values
+      when predicate, mapping_predicate then filtered.any?
+      else
+        raise ArgumentError, "#{method_name} is not a recognized method for category '#{@type}'"
+      end
+    end
+
+    private
+
+    def method_names
+      @method_names ||= Set[plural, predicate, mapping_method, mapping_predicate].freeze
+    end
+
+    def key_pattern
+      @key_pattern ||= /\A#{Regexp.escape(@type.upcase)}#{Regexp.escape(TopSecret::LABEL_DELIMITER)}\d+\z/
+    end
+
+    def filter_mapping(mapping)
+      mapping.select { |key, _| key.to_s.match?(key_pattern) }
+    end
+  end
+end

--- a/lib/top_secret/constants.rb
+++ b/lib/top_secret/constants.rb
@@ -25,4 +25,7 @@ module TopSecret
 
   # @return [Float] The minimum confidence score for NER filtering
   MIN_CONFIDENCE_SCORE = 0.5
+
+  # @return [String] The delimiter used in label names
+  LABEL_DELIMITER = "_"
 end

--- a/lib/top_secret/mapping.rb
+++ b/lib/top_secret/mapping.rb
@@ -1,6 +1,34 @@
 # frozen_string_literal: true
 
 module TopSecret
+  # Provides dynamic category methods for querying sensitive information by type.
+  #
+  # This module automatically generates methods for accessing sensitive information
+  # organized by category (emails, credit cards, people, etc.). Methods are available
+  # for all default filter types and any custom labels used in the mapping.
+  #
+  # @example Querying emails
+  #   result = TopSecret::Text.filter("Contact ralph@example.com")
+  #   result.emails?         # => true
+  #   result.emails          # => ["ralph@example.com"]
+  #   result.email_mapping   # => {:EMAIL_1=>"ralph@example.com"}
+  #
+  # @example With no matches
+  #   result = TopSecret::Text.filter("No sensitive data")
+  #   result.emails?         # => false
+  #   result.emails          # => []
+  #   result.email_mapping   # => {}
+  #
+  # @example Custom labels
+  #   result = TopSecret::Text.filter(
+  #     "user[at]example.com",
+  #     email_filter: TopSecret::Filters::Regex.new(
+  #       label: "EMAIL_ADDRESS",
+  #       regex: /\w+\[at\]\w+\.\w+/
+  #     )
+  #   )
+  #   result.email_addresses          # => ["user[at]example.com"]
+  #   result.email_address_mapping    # => {:EMAIL_ADDRESS_1=>"user[at]example.com"}
   module Mapping
     # @return [Boolean] Whether sensitive information was found
     def sensitive?
@@ -10,6 +38,50 @@ module TopSecret
     # @return [Boolean] Whether sensitive information was not found
     def safe?
       !sensitive?
+    end
+
+    def method_missing(method_name, *args, &block)
+      category = category_for(method_name)
+
+      if category
+        result = category.resolve(method_name, mapping)
+        define_singleton_method(method_name) { result }
+        result
+      else
+        super
+      end
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      category_for(method_name) || super
+    end
+
+    # Returns categories that have matches in the mapping.
+    #
+    # @return [Array<Symbol>] List of categories with matches
+    def categories
+      @categories ||= category_objects.select { |c| c.matches?(mapping) }.map { |c| c.type.to_sym }
+    end
+
+    private
+
+    def category_objects
+      @category_objects ||= Category.from(mapping:, filters: default_filters)
+    end
+
+    def category_for(method_name)
+      category_objects.find { |c| c.respond_to_method?(method_name) }
+    end
+
+    def default_filters
+      @default_filters ||= [
+        TopSecret.credit_card_filter,
+        TopSecret.email_filter,
+        TopSecret.phone_number_filter,
+        TopSecret.ssn_filter,
+        TopSecret.people_filter,
+        TopSecret.location_filter
+      ].compact
     end
   end
 end

--- a/lib/top_secret/text/global_mapping.rb
+++ b/lib/top_secret/text/global_mapping.rb
@@ -50,11 +50,11 @@ module TopSecret
       # @param individual_key [Symbol] The individual key from a filter result
       # @return [Symbol] The global key with consistent numbering
       def generate_global_key(individual_key)
-        label_type = individual_key.to_s.rpartition("_").first
+        label_type = individual_key.to_s.rpartition(TopSecret::LABEL_DELIMITER).first
 
         label_counters[label_type] ||= 0
         label_counters[label_type] += 1
-        :"#{label_type}_#{label_counters[label_type]}"
+        :"#{label_type}#{TopSecret::LABEL_DELIMITER}#{label_counters[label_type]}"
       end
     end
   end

--- a/spec/top_secret/category_spec.rb
+++ b/spec/top_secret/category_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+RSpec.describe TopSecret::Category do
+  describe "method names" do
+    it "derives method names from a simple type" do
+      category = described_class.new(:email)
+
+      expect(category.plural).to eq(:emails)
+      expect(category.predicate).to eq(:emails?)
+      expect(category.mapping_method).to eq(:email_mapping)
+      expect(category.mapping_predicate).to eq(:email_mapping?)
+    end
+
+    it "derives method names from a compound type" do
+      category = described_class.new(:credit_card)
+
+      expect(category.plural).to eq(:credit_cards)
+      expect(category.mapping_method).to eq(:credit_card_mapping)
+    end
+
+    it "resolves a mapping method" do
+      category = described_class.new(:email)
+      mapping = {EMAIL_1: "ralph@example.com", EMAIL_2: "ruby@example.com", PERSON_1: "Ralph"}
+
+      expect(category.resolve(:email_mapping, mapping)).to eq({
+        EMAIL_1: "ralph@example.com",
+        EMAIL_2: "ruby@example.com"
+      })
+    end
+
+    it "pluralizes the type before appending _mapping when the type already ends in _mapping" do
+      category = described_class.new(:network_mapping)
+
+      expect(category.plural).to eq(:network_mappings)
+      expect(category.predicate).to eq(:network_mappings?)
+      expect(category.mapping_method).to eq(:network_mappings_mapping)
+      expect(category.mapping_predicate).to eq(:network_mappings_mapping?)
+    end
+
+    it "matches when the mapping contains keys for the category" do
+      category = described_class.new(:email)
+
+      expect(category.matches?({EMAIL_1: "ralph@example.com", PERSON_1: "Ralph"})).to be true
+      expect(category.matches?({PERSON_1: "Ralph"})).to be false
+    end
+
+    it "raises when resolving an unrecognized method name" do
+      category = described_class.new(:email)
+
+      expect { category.resolve(:unknown, {}) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe ".from" do
+    it "builds categories from a mapping and filters" do
+      mapping = {EMAIL_1: "ralph@example.com", PERSON_1: "Ralph"}
+      filters = [
+        TopSecret.email_filter,
+        TopSecret.people_filter
+      ].compact
+
+      categories = described_class.from(mapping:, filters:)
+
+      expect(categories.map(&:type)).to match_array(%w[email person])
+    end
+  end
+end

--- a/spec/top_secret/result_spec.rb
+++ b/spec/top_secret/result_spec.rb
@@ -38,4 +38,123 @@ RSpec.describe TopSecret::Text::Result do
       end
     end
   end
+
+  describe "categorization" do
+    let(:mapping) do
+      {
+        EMAIL_1: "ralph@example.com",
+        EMAIL_2: "ruby@example.com",
+        PERSON_1: "Ralph",
+        IP_ADDRESS_1: "192.168.1.1",
+        CREDIT_CARD_NUMBER_1: "4242424242424242",
+        NETWORK_MAPPING_1: "10.0.1.0/24 -> 192.168.1.0/24",
+        PORT_MAPPING_RULE_1: "80:8080"
+      }
+    end
+
+    it "categorizes by labels" do
+      expect(subject.emails?).to be true
+      expect(subject.people?).to be true
+      expect(subject.credit_card_numbers?).to be true
+      expect(subject.network_mappings?).to be true
+      expect(subject.port_mapping_rules?).to be true
+
+      expect(subject.emails).to eq([
+        "ralph@example.com",
+        "ruby@example.com"
+      ])
+      expect(subject.people).to eq([
+        "Ralph"
+      ])
+      expect(subject.credit_card_numbers).to eq([
+        "4242424242424242"
+      ])
+      expect(subject.network_mappings).to eq([
+        "10.0.1.0/24 -> 192.168.1.0/24"
+      ])
+      expect(subject.port_mapping_rules).to eq([
+        "80:8080"
+      ])
+
+      expect(subject.email_mapping).to eq({
+        EMAIL_1: "ralph@example.com",
+        EMAIL_2: "ruby@example.com"
+      })
+      expect(subject.person_mapping).to eq({
+        PERSON_1: "Ralph"
+      })
+      expect(subject.credit_card_number_mapping).to eq({
+        CREDIT_CARD_NUMBER_1: "4242424242424242"
+      })
+      expect(subject.network_mappings_mapping).to eq({
+        NETWORK_MAPPING_1: "10.0.1.0/24 -> 192.168.1.0/24"
+      })
+      expect(subject.port_mapping_rule_mapping).to eq({
+        PORT_MAPPING_RULE_1: "80:8080"
+      })
+    end
+
+    it "only includes categories that have matches in the mapping" do
+      expect(subject.categories).to match_array(
+        [:email, :person, :ip_address, :credit_card_number, :network_mapping, :port_mapping_rule]
+      )
+    end
+
+    context "when labels share a common prefix" do
+      let(:mapping) do
+        {
+          EMAIL_1: "ralph@example.com",
+          EMAIL_ADDRESS_1: "ruby@example.com"
+        }
+      end
+
+      it "does not conflate labels with overlapping prefixes" do
+        expect(subject.email_mapping).to eq({
+          EMAIL_1: "ralph@example.com"
+        })
+
+        expect(subject.email_address_mapping).to eq({
+          EMAIL_ADDRESS_1: "ruby@example.com"
+        })
+      end
+
+      it "returns distinct values for each category" do
+        expect(subject.emails).to eq(["ralph@example.com"])
+        expect(subject.email_addresses).to eq(["ruby@example.com"])
+      end
+    end
+
+    it "does not leak custom label methods across instances" do
+      result_a = described_class.new("input", "output", {WIDGET_1: "sprocket"})
+      result_b = described_class.new("input", "output", {EMAIL_1: "ralph@example.com"})
+
+      result_a.widgets
+
+      expect(result_b).not_to respond_to(:widgets)
+    end
+
+    it "responds to dynamic methods" do
+      expect(subject).to respond_to(:emails)
+      expect(subject).to respond_to(:emails?)
+      expect(subject).to respond_to(:email_mapping)
+      expect(subject).to respond_to(:people)
+      expect(subject).to respond_to(:people?)
+      expect(subject).to respond_to(:person_mapping)
+      expect(subject).to respond_to(:credit_card_numbers)
+      expect(subject).to respond_to(:credit_card_numbers?)
+      expect(subject).to respond_to(:credit_card_number_mapping)
+      expect(subject).to respond_to(:network_mappings)
+      expect(subject).to respond_to(:network_mappings_mapping?)
+      expect(subject).to respond_to(:network_mappings_mapping)
+      expect(subject).to respond_to(:port_mapping_rules)
+      expect(subject).to respond_to(:port_mapping_rules?)
+      expect(subject).to respond_to(:port_mapping_rule_mapping)
+    end
+
+    context "when a dynamic method does not exist" do
+      it "does not respond" do
+        expect(subject).not_to respond_to(:junk)
+      end
+    end
+  end
 end

--- a/spec/top_secret/text_spec.rb
+++ b/spec/top_secret/text_spec.rb
@@ -43,6 +43,127 @@ RSpec.describe TopSecret::Text do
       expect(result.safe?).to eq(false)
     end
 
+    it "categorizes sensitive information from free text" do
+      input = <<~TEXT
+        My name is Ralph
+        My location is Boston
+        My email address is user@example.com
+        My credit card numbers are 4242-4242-4242-4242 and 4141414141414141
+        My social security number is 123-45-6789
+        My phone number is 555-555-5555
+      TEXT
+
+      result = TopSecret::Text.filter(input)
+
+      expect(result.emails).to eq(["user@example.com"])
+      expect(result.emails?).to eq(true)
+      expect(result.email_mapping).to eq({EMAIL_1: "user@example.com"})
+
+      expect(result.people).to eq(["Ralph"])
+      expect(result.people?).to eq(true)
+      expect(result.person_mapping).to eq({PERSON_1: "Ralph"})
+
+      expect(result.locations).to eq(["Boston"])
+      expect(result.locations?).to eq(true)
+      expect(result.location_mapping).to eq({LOCATION_1: "Boston"})
+
+      expect(result.credit_cards).to eq(["4242-4242-4242-4242", "4141414141414141"])
+      expect(result.credit_cards?).to eq(true)
+      expect(result.credit_card_mapping).to eq({
+        CREDIT_CARD_1: "4242-4242-4242-4242",
+        CREDIT_CARD_2: "4141414141414141"
+      })
+
+      expect(result.ssns).to eq(["123-45-6789"])
+      expect(result.ssns?).to eq(true)
+      expect(result.ssn_mapping).to eq({SSN_1: "123-45-6789"})
+
+      expect(result.phone_numbers).to eq(["555-555-5555"])
+      expect(result.phone_numbers?).to eq(true)
+      expect(result.phone_number_mapping).to eq({PHONE_NUMBER_1: "555-555-5555"})
+
+      expect(result.categories).to match_array(
+        [:email, :person, :location, :credit_card, :ssn, :phone_number]
+      )
+    end
+
+    context "when there is no sensitive information" do
+      before do
+        stub_ner_entities
+      end
+
+      it "categorizes sensitive information from free text" do
+        result = TopSecret::Text.filter("")
+
+        expect(result.emails).to eq([])
+        expect(result.emails?).to eq(false)
+        expect(result.email_mapping).to eq({})
+
+        expect(result.people).to eq([])
+        expect(result.people?).to eq(false)
+        expect(result.person_mapping).to eq({})
+
+        expect(result.locations).to eq([])
+        expect(result.locations?).to eq(false)
+        expect(result.location_mapping).to eq({})
+
+        expect(result.credit_cards).to eq([])
+        expect(result.credit_cards?).to eq(false)
+        expect(result.credit_card_mapping).to eq({})
+
+        expect(result.ssns).to eq([])
+        expect(result.ssns?).to eq(false)
+        expect(result.ssn_mapping).to eq({})
+
+        expect(result.phone_numbers).to eq([])
+        expect(result.phone_numbers?).to eq(false)
+        expect(result.phone_number_mapping).to eq({})
+
+        expect(result.categories).to eq([])
+      end
+    end
+
+    context "when a custom label is used" do
+      it "categorizes sensitive information from free text using that label" do
+        input = "user[at]example.com"
+
+        result = TopSecret::Text.filter(input, email_filter: TopSecret::Filters::Regex.new(
+          label: "EMAIL_ADDRESS",
+          regex: /user\[at\]example\.com/
+        ))
+
+        expect(result.email_addresses).to eq([input])
+        expect(result.email_addresses?).to eq(true)
+        expect(result.email_address_mapping).to eq({EMAIL_ADDRESS_1: input})
+      end
+
+      it "does not conflate a custom label with the default label" do
+        input = "user[at]example.com"
+
+        result = TopSecret::Text.filter(input, email_filter: TopSecret::Filters::Regex.new(
+          label: "EMAIL_ADDRESS",
+          regex: /user\[at\]example\.com/
+        ))
+
+        expect(result.emails).to eq([])
+        expect(result.emails?).to eq(false)
+        expect(result.email_mapping).to eq({})
+      end
+
+      it "returns data through default methods when the custom label matches the default" do
+        input = "user[at]example.com"
+
+        result = TopSecret::Text.filter(input, email_filter: TopSecret::Filters::Regex.new(
+          label: "EMAIL",
+          regex: /user\[at\]example\.com/
+        ))
+
+        expect(result.emails).to eq([input])
+        expect(result.emails?).to eq(true)
+        expect(result.email_mapping).to eq({EMAIL_1: input})
+      end
+    end
+
     context "when the filters option is passed" do
       it "overrides existing Regex filters" do
         input = <<~TEXT
@@ -562,6 +683,50 @@ RSpec.describe TopSecret::Text do
           false,
           true
         ])
+      end
+    end
+
+    it "categorizes sensitive information from free text" do
+      result = TopSecret::Text.filter_all([
+        "user@example.com"
+      ])
+
+      expect(result.items.map(&:emails)).to eq([["user@example.com"]])
+      expect(result.items.map(&:emails?)).to eq([true])
+      expect(result.items.map(&:email_mapping)).to eq([{EMAIL_1: "user@example.com"}])
+
+      expect(result.items.map(&:categories)).to eq([[:email]])
+    end
+
+    context "when there is no sensitive information" do
+      it "responds to the default filters" do
+        result = TopSecret::Text.filter_all([""])
+
+        expect(result.items.map(&:emails)).to all(be_empty)
+        expect(result.items.map(&:emails?)).to all(be false)
+        expect(result.items.map(&:email_mapping)).to all(be_empty)
+
+        expect(result.items.map(&:credit_cards)).to all(be_empty)
+        expect(result.items.map(&:credit_cards?)).to all(be false)
+        expect(result.items.map(&:credit_card_mapping)).to all(be_empty)
+
+        expect(result.items.map(&:phone_numbers)).to all(be_empty)
+        expect(result.items.map(&:phone_numbers?)).to all(be false)
+        expect(result.items.map(&:phone_number_mapping)).to all(be_empty)
+
+        expect(result.items.map(&:ssns)).to all(be_empty)
+        expect(result.items.map(&:ssns?)).to all(be false)
+        expect(result.items.map(&:ssn_mapping)).to all(be_empty)
+
+        expect(result.items.map(&:people)).to all(be_empty)
+        expect(result.items.map(&:people?)).to all(be false)
+        expect(result.items.map(&:person_mapping)).to all(be_empty)
+
+        expect(result.items.map(&:locations)).to all(be_empty)
+        expect(result.items.map(&:locations?)).to all(be false)
+        expect(result.items.map(&:location_mapping)).to all(be_empty)
+
+        expect(result.items.map(&:categories)).to all(be_empty)
       end
     end
 


### PR DESCRIPTION
Follow-up to #89.

Now that we enforce a specific label format, we can dynamically generate
methods based on the types of data that was filtered.

```ruby
result = TopSecret::Text.filter("Ralph can be reached at ralph@example.com")

result.categories
# => [:email, :person]

result.emails?
# => true
result.emails
# => ["ralph@example.com"]
result.email_mapping
# => {EMAIL_1 => "ralph@example.com"}

result.people?
# => true
result.people
# => ["Ralph"]
result.person_mapping
# => {PERSON_1 => "Ralph"}

result.credit_cards?
# => false
result.credit_cards
# => []
result.credit_card_mapping
# => {}
```

Note that we don't conflate labels with common prefixes. This means `EMAIL_1`
and `EMAIL_ADDRESS_1` will be stored under `email_mapping` and
`email_address_mapping`.

In an effort to avoid leaking these category methods across different
instances, we avoid calling `self.class.define_method`.
