### PR TITLE
Require MFA for gem pushes

### DIFF
--- a/top_secret.gemspec
+++ b/top_secret.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = "https://github.com/thoughtbot/top_secret/blob/main/CHANGELOG.md"
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
This adds the `rubygems_mfa_required` metadata to the gemspec, requiring multi-factor authentication for privileged operations on RubyGems.org.

This is a protection against supply chain attacks like the recent NPM Axios compromise: https://socket.dev/blog/axios-npm-package-compromised

Reference: https://guides.rubygems.org/mfa-requirement-opt-in/