### PR TITLE
Prevent filtering labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+-   Fixed malformed output when a redacted label contains text that matches another filter (e.g., `MA` inside `[EMAIL_1]` being re-filtered to `[E[LOCATION_2]IL_1]`)
+
 ## [1.0.0] - 2026-03-25
 
 ### Added

--- a/lib/top_secret/text.rb
+++ b/lib/top_secret/text.rb
@@ -214,9 +214,13 @@ module TopSecret
     #
     # @return [void]
     def substitute_text
-      mapping.each do |filter, value|
-        output.gsub! value, "[#{filter}]"
+      return if mapping.empty?
+
+      value_to_label = mapping.each_with_object({}) do |(filter, value), hash|
+        hash[value] = "[#{filter}]"
       end
+      pattern = Regexp.union(value_to_label.keys)
+      output.gsub!(pattern, value_to_label)
     end
 
     # Collects all filters to apply: default filters with overrides plus custom filters

--- a/lib/top_secret/text/result.rb
+++ b/lib/top_secret/text/result.rb
@@ -45,10 +45,13 @@ module TopSecret
       # @param global_mapping [Hash] Global mapping from filter labels to original values
       # @return [Array<Result>] Array of Result objects with globally consistent redaction and individual mappings
       def self.with_global_labels(individual_results, global_mapping)
+        value_to_label = global_mapping.each_with_object({}) do |(filter, value), hash|
+          hash[value] = "[#{filter}]"
+        end
+        pattern = Regexp.union(value_to_label.keys)
+
         individual_results.map do |result|
-          output = global_mapping.reduce(result.input.dup) do |text, (filter, value)|
-            text.gsub(value, "[#{filter}]")
-          end
+          output = result.input.gsub(pattern, value_to_label)
           filter_keys = output.scan(/\[([^\]]+)\]/).flatten.map(&:to_sym)
           mapping = global_mapping.slice(*filter_keys)
           new(result.input, output, mapping)

--- a/spec/top_secret/text_spec.rb
+++ b/spec/top_secret/text_spec.rb
@@ -43,6 +43,41 @@ RSpec.describe TopSecret::Text do
       expect(result.safe?).to eq(false)
     end
 
+    context "when a label matches a filter" do
+      let(:ma) { build_entity(text: "MA", tag: :location) }
+      let(:boston) { build_entity(text: "Boston", tag: :location) }
+
+      before do
+        stub_ner_entities(boston, ma)
+      end
+
+      it "does not re-filter labels" do
+        input = "Build a profile for a person with email user@example.com located in Boston, MA."
+
+        result = TopSecret::Text.filter(input)
+
+        expect(result.output).to eq(
+          "Build a profile for a person with email [EMAIL_1] located in [LOCATION_1], [LOCATION_2]."
+        )
+      end
+    end
+
+    context "when a custom filter matches the same value as a default filter" do
+      it "uses the custom filter's label" do
+        custom_filter = TopSecret::Filters::Regex.new(
+          label: "CUSTOM_EMAIL",
+          regex: /user@example\.com/
+        )
+
+        result = TopSecret::Text.filter(
+          "Contact user@example.com",
+          custom_filters: [custom_filter]
+        )
+
+        expect(result.output).to eq("Contact [CUSTOM_EMAIL_1]")
+      end
+    end
+
     it "categorizes sensitive information from free text" do
       input = <<~TEXT
         My name is Ralph
@@ -727,6 +762,30 @@ RSpec.describe TopSecret::Text do
         expect(result.items.map(&:location_mapping)).to all(be_empty)
 
         expect(result.items.map(&:categories)).to all(be_empty)
+      end
+    end
+
+    context "when a label matches a filter" do
+      before do
+        ma = build_entity(text: "MA", tag: :location)
+        boston = build_entity(text: "Boston", tag: :location)
+        stub_ner_entities(boston, ma)
+      end
+
+      it "does not re-filter labels" do
+        messages = [
+          "Email user@example.com in Boston, MA.",
+          "Contact admin@example.com in Boston."
+        ]
+
+        result = TopSecret::Text.filter_all(messages)
+
+        expect(result.items[0].output).to eq(
+          "Email [EMAIL_1] in [LOCATION_1], [LOCATION_2]."
+        )
+        expect(result.items[1].output).to eq(
+          "Contact [EMAIL_2] in [LOCATION_1]."
+        )
       end
     end
 


### PR DESCRIPTION
**To Do**

- [x] Manually QA with demo app

---

Closes #98

Prior to this commit, we were making multiple passes over the
substituted text, resulting in labels being filtered.

This commit substitutes the text on one pass.
