### PR TITLE
Add minimal mutant setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.bundle/
 /.yardoc
+/.mutant/
 /_yardoc/
 /coverage/
 /doc/

--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,5 @@ gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 
 gem "standard", "~> 1.3"
+
+gem "mutant-rspec", "~> 0.16.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,8 +48,19 @@ GEM
       prism (~> 1.5)
     mitie (0.3.2)
       fiddle
+    mutant (0.16.2)
+      diff-lcs (>= 1.6, < 3)
+      irb (~> 1.15)
+      parser (~> 3.3.10)
+      regexp_parser (~> 2.10)
+      securerandom (>= 0.3)
+      sorbet-runtime (~> 0.6.0)
+      unparser (>= 0.8.2, < 0.10)
+    mutant-rspec (0.16.2)
+      mutant (= 0.16.2)
+      rspec-core (>= 3.8.0, < 5.0.0)
     parallel (1.27.0)
-    parser (3.3.9.0)
+    parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
     pp (0.6.2)
@@ -101,6 +112,7 @@ GEM
       rubocop-ast (>= 1.38.0, < 2.0)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
+    sorbet-runtime (0.6.13164)
     standard (1.50.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -119,6 +131,10 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.2.0)
+    unparser (0.9.0)
+      diff-lcs (>= 1.6, < 3)
+      parser (>= 3.3.0)
+      prism (>= 1.5.1)
     uri (1.0.3)
 
 PLATFORMS
@@ -127,6 +143,7 @@ PLATFORMS
 
 DEPENDENCIES
   irb
+  mutant-rspec (~> 0.16.2)
   rake (~> 13.0)
   rspec (~> 3.0)
   standard (~> 1.3)

--- a/config/mutant.yml
+++ b/config/mutant.yml
@@ -1,0 +1,11 @@
+---
+usage: opensource
+includes:
+  - lib
+requires:
+  - top_secret
+integration:
+  name: rspec
+matcher:
+  subjects:
+    - TopSecret*


### PR DESCRIPTION
This configures mutant for in `top_secret`, it intentionally does not:

* Add mutant as a CI gate.
* Attempt to cover any mutation.

This is for after I had a discussion with Luis who invited me to show mutant here ;)

Full mutant run produces this summary:

```
Mutant environment:
Usage:           opensource
Matcher:         #<Mutant::Matcher::Config subjects: [TopSecret*]>
Integration:     rspec
Jobs:            128
Includes:        ["lib"]
Requires:        ["top_secret"]
Operators:       light
MutationTimeout: 5
Subjects:        61
All-Tests:       116
Available-Tests: 116
Selected-Tests:  116
Tests/Subject:   1.90 avg
Mutations:       1482
Results:         1482
Kills:           1121
Alive:           361
Timeouts:        0
Runtime:         4.91s
Killtime:        101.32s
Efficiency:      2061.66%
Mutations/s:     301.57
Coverage:        75.64%
```

Note I work on a riddiculous machine (128 threads) will be slower on other computers. And a full pass is only useful for very small projects, regular CI / interactive / agent use would normally go for `--since main` / `--fail-fast`.

Claude was so nice to make me this summary on the alive mutations:

```
  Top alive-mutation hotspots (worth attacking first):

  ┌────────────────────────────────────────┬─────────────────┬──────────────────────────────────────────┐
  │                Subject                 │ Alive (visible) │                   File                   │
  ├────────────────────────────────────────┼─────────────────┼──────────────────────────────────────────┤
  │ Text::Result.with_global_labels        │ 86              │ lib/top_secret/text/result.rb:47         │
  ├────────────────────────────────────────┼─────────────────┼──────────────────────────────────────────┤
  │ Text::Result.from_messages             │ 50              │ lib/top_secret/text/result.rb:34         │
  ├────────────────────────────────────────┼─────────────────┼──────────────────────────────────────────┤
  │ Text::BatchResult.from_messages        │ 48              │ lib/top_secret/text/batch_result.rb:33   │
  ├────────────────────────────────────────┼─────────────────┼──────────────────────────────────────────┤
  │ Text.shared_model                      │ 24              │ lib/top_secret/text.rb:21                │
  ├────────────────────────────────────────┼─────────────────┼──────────────────────────────────────────┤
  │ Text::BatchResult#initialize           │ 5               │ lib/top_secret/text/batch_result.rb:21   │
  ├────────────────────────────────────────┼─────────────────┼──────────────────────────────────────────┤
  │ Text::Result#initialize                │ 3               │ lib/top_secret/text/result.rb:21         │
  ├────────────────────────────────────────┼─────────────────┼──────────────────────────────────────────┤
  │ Text::GlobalMapping#process_result     │ 1+              │ lib/top_secret/text/global_mapping.rb:40 │
  ├────────────────────────────────────────┼─────────────────┼──────────────────────────────────────────┤
  │ Text::GlobalMapping#build_from_results │ 2               │ lib/top_secret/text/global_mapping.rb:26 │
  ├────────────────────────────────────────┼─────────────────┼──────────────────────────────────────────┤
  │ Text#substitute_text                   │ 4               │ lib/top_secret/text.rb                   │
  ├────────────────────────────────────────┼─────────────────┼──────────────────────────────────────────┤
  │ Text.clear_model_cache!                │ 1               │ lib/top_secret/text.rb:38                │
  └────────────────────────────────────────┴─────────────────┴──────────────────────────────────────────┘

  Patterns of weak coverage that jump out:
  - Batch / global-mapping pipeline is the largest gap — most of the 361 alive mutations cluster there. Specs likely
  assert end-to-end shape but not the intermediate transformations (the global-label substitution loop, the
  value_to_label mapping, etc.).
  - Memoization & mutex semantics in Text.shared_model / clear_model_cache! aren't pinned down — the mutex
  synchronization can be removed without breaking any test.
  - Constructor field assignments (@input, @items) — initializers often have alive nil-substitution mutations because
  tests don't read every getter back after construction.
  - Splat usage (*default_filters.keys vs default_filters.keys) — assert_valid_keys happens to accept both shapes, so
  behavior diverges only on edge inputs no test exercises.

  Want me to start with Text::Result.with_global_labels (the biggest single subject), or open a session subject report
  (mutant session subject ...) for the full mutation list on a target?
```

Most of the alive mutations are "semantically dead code" that can likely just be removed, and many others are a sign of behaviore the code exhibits that probably should not be removed but is "not being pulled into existance by a test that demands that behavior".

I do not expect this to be merged as is will, as I said: Discuss with Luis on this PR ;)