### PR TITLE
Account for multiple filters matching on the same token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+-   Fixed incorrect labeling when multiple filters match the same token. Each occurrence is now labeled by the filter that matched it (e.g., `"My name is Austin, and I live in Austin TX."` now redacts to `"My name is [PERSON_1], and I live in [LOCATION_1] TX."` instead of labeling both occurrences with the last filter to match).
+
 ## [1.0.1] - 2026-04-16
 
 ### Fixed

--- a/lib/top_secret/text.rb
+++ b/lib/top_secret/text.rb
@@ -8,6 +8,7 @@ require_relative "text/batch_result"
 require_relative "text/scan_result"
 require_relative "text/global_mapping"
 require_relative "text/label_sequence"
+require_relative "text/substitution"
 
 module TopSecret
   # Processes text to identify and redact sensitive information using configured filters.
@@ -214,25 +215,7 @@ module TopSecret
     #
     # @return [void]
     def substitute_text
-      return if mapping.empty?
-
-      value_to_labels = mapping.each_with_object({}) do |(filter, value), hash|
-        (hash[value] ||= []) << "[#{filter}]"
-      end
-
-      single_label, multi_label = value_to_labels.partition { |_, labels| labels.size == 1 }.map(&:to_h)
-
-      unless single_label.empty?
-        value_to_label = single_label.transform_values(&:first)
-        pattern = Regexp.union(value_to_label.keys)
-        output.gsub!(pattern, value_to_label)
-      end
-
-      multi_label.each do |value, labels|
-        occurrences = output.scan(value).size
-        chosen = occurrences.positive? ? labels.last(occurrences) : labels.last(1)
-        chosen.each { |label| output.sub!(value, label) }
-      end
+      Substitution.new(mapping).apply!(output)
     end
 
     # Collects all filters to apply: default filters with overrides plus custom filters

--- a/lib/top_secret/text.rb
+++ b/lib/top_secret/text.rb
@@ -216,11 +216,23 @@ module TopSecret
     def substitute_text
       return if mapping.empty?
 
-      value_to_label = mapping.each_with_object({}) do |(filter, value), hash|
-        hash[value] = "[#{filter}]"
+      value_to_labels = mapping.each_with_object({}) do |(filter, value), hash|
+        (hash[value] ||= []) << "[#{filter}]"
       end
-      pattern = Regexp.union(value_to_label.keys)
-      output.gsub!(pattern, value_to_label)
+
+      single_label, multi_label = value_to_labels.partition { |_, labels| labels.size == 1 }.map(&:to_h)
+
+      unless single_label.empty?
+        value_to_label = single_label.transform_values(&:first)
+        pattern = Regexp.union(value_to_label.keys)
+        output.gsub!(pattern, value_to_label)
+      end
+
+      multi_label.each do |value, labels|
+        occurrences = output.scan(value).size
+        chosen = occurrences.positive? ? labels.last(occurrences) : labels.last(1)
+        chosen.each { |label| output.sub!(value, label) }
+      end
     end
 
     # Collects all filters to apply: default filters with overrides plus custom filters

--- a/lib/top_secret/text/substitution.rb
+++ b/lib/top_secret/text/substitution.rb
@@ -58,7 +58,8 @@ module TopSecret
         occurrences = output.scan(value).size
         return labels.last(1) if occurrences.zero?
 
-        labels.last(occurrences)
+        chosen = labels.last(occurrences)
+        chosen + Array.new(occurrences - chosen.size, labels.last)
       end
     end
   end

--- a/lib/top_secret/text/substitution.rb
+++ b/lib/top_secret/text/substitution.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module TopSecret
+  class Text
+    # Replaces matched values in text with their label placeholders.
+    #
+    # When a value is matched by a single filter, every occurrence is replaced
+    # with that label. When a value is matched by multiple filters, occurrences
+    # are labeled in filter order; if there are more labels than occurrences,
+    # the later labels win (preserving "custom filter overrides default" semantics).
+    class Substitution
+      def initialize(mapping)
+        @mapping = mapping
+      end
+
+      def apply!(output)
+        return output if labels_by_value.empty?
+
+        substitute_single_label_values!(output)
+        substitute_multi_label_values!(output)
+        output
+      end
+
+      private
+
+      attr_reader :mapping
+
+      def labels_by_value
+        @labels_by_value ||= mapping.each_with_object({}) do |(filter, value), hash|
+          (hash[value] ||= []) << "[#{filter}]"
+        end
+      end
+
+      def single_label_values
+        labels_by_value.select { |_, labels| labels.one? }
+      end
+
+      def multi_label_values
+        labels_by_value.reject { |_, labels| labels.one? }
+      end
+
+      def substitute_single_label_values!(output)
+        return if single_label_values.empty?
+
+        value_to_label = single_label_values.transform_values(&:first)
+        output.gsub!(Regexp.union(value_to_label.keys), value_to_label)
+      end
+
+      def substitute_multi_label_values!(output)
+        multi_label_values.each do |value, labels|
+          labels_for_each_occurrence(value, labels, output).each do |label|
+            output.sub!(value, label)
+          end
+        end
+      end
+
+      def labels_for_each_occurrence(value, labels, output)
+        occurrences = output.scan(value).size
+        return labels.last(1) if occurrences.zero?
+
+        labels.last(occurrences)
+      end
+    end
+  end
+end

--- a/spec/top_secret/text_spec.rb
+++ b/spec/top_secret/text_spec.rb
@@ -62,6 +62,59 @@ RSpec.describe TopSecret::Text do
       end
     end
 
+    context "when the same value matches multiple filters" do
+      let(:austin_person) { build_entity(text: "Austin", tag: :person) }
+      let(:austin_location) { build_entity(text: "Austin", tag: :location) }
+
+      before do
+        stub_ner_entities(austin_person, austin_location)
+      end
+
+      it "labels each occurrence according to the filter that matched it" do
+        input = "My name is Austin, and I live in Austin TX."
+
+        result = TopSecret::Text.filter(input)
+
+        expect(result.output).to eq(
+          "My name is [PERSON_1], and I live in [LOCATION_1] TX."
+        )
+        expect(result.mapping).to eq({
+          PERSON_1: "Austin",
+          LOCATION_1: "Austin"
+        })
+      end
+    end
+
+    context "when the same value matches multiple non-NER filters" do
+      before do
+        stub_ner_entities
+      end
+
+      it "labels each occurrence according to the filter that matched it" do
+        ip_filter = TopSecret::Filters::Regex.new(
+          label: "IP_ADDRESS",
+          regex: /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/
+        )
+        server_filter = TopSecret::Filters::Regex.new(
+          label: "SERVER",
+          regex: /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/
+        )
+
+        result = TopSecret::Text.filter(
+          "Primary 192.168.1.1, backup 192.168.1.1.",
+          custom_filters: [ip_filter, server_filter]
+        )
+
+        expect(result.output).to eq(
+          "Primary [IP_ADDRESS_1], backup [SERVER_1]."
+        )
+        expect(result.mapping).to eq({
+          IP_ADDRESS_1: "192.168.1.1",
+          SERVER_1: "192.168.1.1"
+        })
+      end
+    end
+
     context "when a custom filter matches the same value as a default filter" do
       it "uses the custom filter's label" do
         custom_filter = TopSecret::Filters::Regex.new(

--- a/spec/top_secret/text_spec.rb
+++ b/spec/top_secret/text_spec.rb
@@ -85,6 +85,25 @@ RSpec.describe TopSecret::Text do
       end
     end
 
+    context "when the same value appears more times than the filters that matched it" do
+      let(:austin_person) { build_entity(text: "Austin", tag: :person) }
+      let(:austin_location) { build_entity(text: "Austin", tag: :location) }
+
+      before do
+        stub_ner_entities(austin_person, austin_location)
+      end
+
+      it "redacts every occurrence, falling back to the last matching filter's label" do
+        input = "Austin met Austin near Austin."
+
+        result = TopSecret::Text.filter(input)
+
+        expect(result.output).to eq(
+          "[PERSON_1] met [LOCATION_1] near [LOCATION_1]."
+        )
+      end
+    end
+
     context "when the same value matches multiple non-NER filters" do
       before do
         stub_ner_entities


### PR DESCRIPTION
Relates to: https://github.com/thoughtbot/top_secret/discussions/51

Prior to this commit, if multiple filters matched the same token, filter
precedence would account for the labeling:

```ruby
result = TopSecret::Text.filter("My name is Austin, and I live in Austin TX.")

result.output
# => "My name is [PERSON_1], and I live in [PERSON_1] TX."
```

This commit ensures each filter is labeled correctly.

```ruby
result = TopSecret::Text.filter("My name is Austin, and I live in Austin TX.")

result.output
# => "My name is [PERSON_1], and I live in [LOCATION_1] TX."
```
