### PR TITLE
Issue #82 Capture leading paren in PHONE_REGEX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+-   `PHONE_REGEX` now captures the leading `(` when a parenthesized phone number is embedded in surrounding text (e.g., `"My phone number is (555) 555-5555"`). Previously the `\b` word boundary refused to anchor before `(`, leaving the paren behind in the source string.
+
 ## [1.0.1] - 2026-04-16
 
 ### Fixed

--- a/lib/top_secret/constants.rb
+++ b/lib/top_secret/constants.rb
@@ -17,8 +17,14 @@ module TopSecret
     (?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*
   }x
 
-  # @return [Regexp] Matches phone numbers with optional country code
-  PHONE_REGEX = /\b(?:\+\d{1,2}\s)?\(?\d{3}\)?[\s+.-]\d{3}[\s+.-]\d{4}\b/
+  # @return [Regexp] Matches phone numbers with optional country code.
+  #
+  # Uses digit-only lookaround anchors instead of `\b` so an optional
+  # leading `(` is included in the match. `\b` is a word-boundary
+  # assertion and `(` is a non-word character, so a leading `\b` would
+  # refuse to anchor before `(` and the engine would start the match at
+  # the first digit, leaving the `(` behind in the source text.
+  PHONE_REGEX = /(?<!\d)(?:\+\d{1,2}\s)?\(?\d{3}\)?[\s+.-]\d{3}[\s+.-]\d{4}(?!\d)/
 
   # @return [Regexp] Matches Social Security Numbers in common formats
   SSN_REGEX = /\b\d{3}[\s+-]\d{2}[\s+-]\d{4}\b/

--- a/spec/top_secret/constants_spec.rb
+++ b/spec/top_secret/constants_spec.rb
@@ -21,12 +21,14 @@ RSpec.describe "TopSecret::PHONE_REGEX" do
     end
   end
 
-  it "captures the leading paren when embedded in surrounding text" do
-    input = "My phone number is (555) 555-5555"
+  context "when embedded in surrounding text" do
+    it "captures the leading paren" do
+      input = "My phone number is (555) 555-5555"
 
-    match = input.match(TopSecret::PHONE_REGEX)
+      match = input.match(TopSecret::PHONE_REGEX)
 
-    expect(match[0]).to eq("(555) 555-5555")
+      expect(match[0]).to eq("(555) 555-5555")
+    end
   end
 
   it "does not match a longer digit run" do

--- a/spec/top_secret/constants_spec.rb
+++ b/spec/top_secret/constants_spec.rb
@@ -13,5 +13,23 @@ RSpec.describe "TopSecret::PHONE_REGEX" do
     it "matches #{phone_number}" do
       expect(phone_number).to match(TopSecret::PHONE_REGEX)
     end
+
+    it "captures the full #{phone_number} (no leading/trailing chars left behind)" do
+      match = phone_number.match(TopSecret::PHONE_REGEX)
+
+      expect(match[0]).to eq(phone_number)
+    end
+  end
+
+  it "captures the leading paren when embedded in surrounding text" do
+    input = "My phone number is (555) 555-5555"
+
+    match = input.match(TopSecret::PHONE_REGEX)
+
+    expect(match[0]).to eq("(555) 555-5555")
+  end
+
+  it "does not match a longer digit run" do
+    expect("12345678901234").not_to match(TopSecret::PHONE_REGEX)
   end
 end


### PR DESCRIPTION
## Why?

The existing PHONE_REGEX does not catch the leading paren on phone numbers where the
area code or prefix is inside parentheses.

`TopSecret::PHONE_REGEX` is anchored with `\b` at the start. Because
  `\b` is a word-boundary assertion and `(` is a non-word character,
  the boundary refuses to anchor immediately before `(`. The engine
  falls back to starting the match at the first digit, leaving the
  leading `(` un-redacted.

  ```ruby
  input = "My phone number is (555) 555-5555"
  TopSecret::Text.filter(input)
  # => "My phone number is ([PHONE_NUMBER_1]"   # stray (
  # mapping: { PHONE_NUMBER_1: "555) 555-5555" } # missing (
```

There is an existing ticket #82 and some existing, broader PRs, but this
is a targeted fix for this one specific issue.

## What does this do?

  This swaps the \b anchors for digit-only lookarounds
  ((?<!\d) / (?!\d)) so the optional ( participates in the
  match while still preventing matches from starting or ending in the
  middle of a longer digit run.

  Test plan

  - All existing PHONE_REGEX fixtures still match
  - New spec: MatchData[0] equals the full input for every fixture
  - New spec: embedded "My phone number is (555) 555-5555" captures the paren
  - New spec: "12345678901234" does not match

  Refs #82 (closed as stale; bug still present on main).